### PR TITLE
Set up Posthog web analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig({
         src: "./src/assets/superplane-logo.svg",
       },
       components: {
+        Head: "./src/components/CustomHead.astro",
         SiteTitle: "./src/components/CustomSiteTitle.astro",
       },
       social: [

--- a/src/components/CustomHead.astro
+++ b/src/components/CustomHead.astro
@@ -1,0 +1,11 @@
+---
+const { head } = Astro.locals.starlightRoute;
+import PostHog from "./posthog.astro";
+---
+
+{
+  head.map(({ tag: Tag, attrs, content }) => (
+    <Tag {...attrs} set:html={content} />
+  ))
+}
+<PostHog />

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -1,0 +1,59 @@
+<script is:inline>
+  !(function (t, e) {
+    var o, n, p, r;
+    e.__SV ||
+      (window.posthog && window.posthog.__loaded) ||
+      ((window.posthog = e),
+      (e._i = []),
+      (e.init = function (i, s, a) {
+        function g(t, e) {
+          var o = e.split(".");
+          (2 == o.length && ((t = t[o[0]]), (e = o[1])),
+            (t[e] = function () {
+              t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+            }));
+        }
+        (((p = t.createElement("script")).type = "text/javascript"),
+          (p.crossOrigin = "anonymous"),
+          (p.async = !0),
+          (p.src =
+            s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") +
+            "/static/array.js"),
+          (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(
+            p,
+            r
+          ));
+        var u = e;
+        for (
+          void 0 !== a ? (u = e[a] = []) : (a = "posthog"),
+            u.people = u.people || [],
+            u.toString = function (t) {
+              var e = "posthog";
+              return (
+                "posthog" !== a && (e += "." + a),
+                t || (e += " (stub)"),
+                e
+              );
+            },
+            u.people.toString = function () {
+              return u.toString(1) + ".people (stub)";
+            },
+            o =
+              "init rs ls yi ns us ts ss capture Hi calculateEventProperties vs register register_once register_for_session unregister unregister_for_session gs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty fs ds createPersonProfile ps Qr opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing hs debug O cs getPageViewId captureTraceFeedback captureTraceMetric Kr".split(
+                " "
+              ),
+            n = 0;
+          n < o.length;
+          n++
+        )
+          g(u, o[n]);
+        e._i.push([i, s, a]);
+      }),
+      (e.__SV = 1));
+  })(document, window.posthog || []);
+  posthog.init("phc_ApOVoE64DryF8wQTTUKaiyUoQSiRyKz79wgaRX1iNxk", {
+    api_host: "https://us.i.posthog.com",
+    defaults: "2025-11-30",
+    person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well
+  });
+</script>


### PR DESCRIPTION
Using the same code as the core website, as per Posthog's recommendation.

---

You're right to think about this carefully! Based on PostHog best practices, you should use the same tracking code and project for both your main website and docs subdomain. Here's why and how to handle it:

Recommended approach

Use the same PostHog project with the same tracking code across both sites. PostHog's JavaScript snippet automatically handles cross-subdomain tracking with first-party cookies (see cross-domain tracking docs (https://posthog.com/tutorials/cross-domain-tracking)).

How to separate the data

While the tracking code is the same, you can easily differentiate between your sites:

1. Web analytics host filter – Web analytics now has a built-in host dropdown that lets you filter to see stats for specific domains/subdomains separately
2. Property filtering – You can filter any insight or dashboard by the $host property to separate your main site from your docs site. For example:- Filter by $host equals yoursite.com for main site stats
- Filter by $host equals docs.yoursite.com for docs stats
3. Create separate dashboards – Set up one dashboard for your main site and another for your docs, each with the appropriate $host filters applied

Why keep them together

- Better user journey tracking – You can see when users navigate from your main site to docs and vice versa
- Accurate conversion tracking – Track complete funnels that span both sites
- Simpler setup – One project to manage instead of two
- Shared user identity – Same person visiting both sites is recognized as the same user

The "misleading pageview numbers" concern is valid for the aggregate view, but you can always filter to see accurate numbers for each property individually. The benefit of seeing the complete picture across your entire web presence typically outweighs having to apply a filter when you want site-specific metrics.