### PR TITLE
feat: add canvas init section into cli docs

### DIFF
--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -86,6 +86,32 @@ superplane canvases get <canvas_name_or_id> -o yaml
 
 ## Managing canvases
 
+### Generate a starter canvas YAML
+
+Print a blank canvas YAML skeleton to stdout:
+
+```sh
+superplane canvases init
+```
+
+Start from an existing template:
+
+```sh
+superplane canvases init --template health-check-monitor
+```
+
+List available templates:
+
+```sh
+superplane canvases init --list-templates
+```
+
+Write directly to a file instead of stdout:
+
+```sh
+superplane canvases init --output-file canvas.yaml
+```
+
 ### Create a canvas
 
 ```sh


### PR DESCRIPTION
This pull request adds documentation for generating starter canvas YAML files using the `superplane canvases init` command. The changes introduce instructions and examples for initializing canvases, starting from templates, listing available templates, and writing output to a file.

**New documentation for canvas initialization:**

* Added a section describing how to generate a blank canvas YAML skeleton using `superplane canvases init`, including usage examples for starting from templates, listing templates, and writing output to a file.