### PR TITLE
fix: expression examples consistency

### DIFF
--- a/src/content/docs/components/Core.mdx
+++ b/src/content/docs/components/Core.mdx
@@ -381,9 +381,9 @@ The expression has access to:
 
 ### Examples
 
-- `$["Node Name"].status == "active"`: Only forward events where status is "active"
-- `$["Node Name"].amount > 1000`: Filter events with amount greater than 1000
-- `$["Node Name"].user.role == "admin" && $["Node Name"].action == "delete"`: Complex condition checking multiple fields
+- `$['Node Name'].data.status == "active"`: Only forward events where status is "active"
+- `$['Node Name'].data.amount > 1000`: Filter events with amount greater than 1000
+- `$['Node Name'].data.user.role == "admin" && $['Node Name'].data.action == "delete"`: Complex condition checking multiple fields
 
 ### Example Output
 
@@ -485,9 +485,9 @@ The expression has access to:
 
 ### Examples
 
-- `$["Node Name"].status == "approved"`: Route approved items to True channel
-- `$["Node Name"].amount > 1000`: Route high-value items to True channel
-- `$["Node Name"].user.role == "admin"`: Route admin actions to True channel
+- `$['Node Name'].data.status == "approved"`: Route approved items to True channel
+- `$['Node Name'].data.amount > 1000`: Route high-value items to True channel
+- `$['Node Name'].data.user.role == "admin"`: Route admin actions to True channel
 
 ### Example Output
 

--- a/src/content/docs/components/DigitalOcean.mdx
+++ b/src/content/docs/components/DigitalOcean.mdx
@@ -2172,7 +2172,7 @@ Spaces Access Key ID and Secret Access Key must be configured in the DigitalOcea
 
 - **Bucket**: The Spaces bucket to upload to. The dropdown lists all buckets — the region is determined automatically.
 - **File Path**: The full path including file name and extension (e.g. reports/2024/daily.csv). The content type is detected automatically from the extension.
-- **Body**: The text content to upload. Supports expressions to pass content from upstream components (e.g. `{{ $['HTTP Request'].body }}`). Only text-based formats are supported (JSON, CSV, YAML, plain text, XML, etc.)
+- **Body**: The text content to upload. Supports expressions to pass content from upstream components (e.g. `{{ $['HTTP Request'].data.body }}`). Only text-based formats are supported (JSON, CSV, YAML, plain text, XML, etc.)
 - **ACL**: Access control — `private` (default) restricts access to the owner, `public-read` makes the object publicly accessible.
 - **Metadata**: Optional key-value pairs stored as object metadata (x-amz-meta-* headers). Supports expressions.
 - **Tags**: Optional key-value tags applied to the object. Can be changed later without re-uploading. Supports expressions.

--- a/src/content/docs/components/Prometheus.mdx
+++ b/src/content/docs/components/Prometheus.mdx
@@ -164,7 +164,7 @@ The Expire Silence component expires an active silence in Alertmanager (`DELETE 
 
 ### Configuration
 
-- **Silence**: Required silence to expire. Supports expressions so users can reference `$['Create Silence'].silenceID`.
+- **Silence**: Required silence to expire. Supports expressions so users can reference `$['Create Silence'].data.silenceID`.
 
 ### Output
 
@@ -228,7 +228,7 @@ The Get Silence component retrieves a silence from Alertmanager (`GET /api/v2/si
 
 ### Configuration
 
-- **Silence**: Required silence to retrieve (supports expressions, e.g. `{{ $['Create Silence'].silenceID }}`)
+- **Silence**: Required silence to retrieve (supports expressions, e.g. `{{ $['Create Silence'].data.silenceID }}`)
 
 ### Output
 

--- a/src/content/docs/concepts/data-flow.md
+++ b/src/content/docs/concepts/data-flow.md
@@ -76,17 +76,17 @@ When the workflow executes, each node adds its output to `$`:
 
 ```json
 {
-  "GitHub onPush": { "ref": "refs/heads/main", "commit": "abc123" },
-  "Filter": { "passed": true },
-  "Deployment": { "status": "success", "url": "https://app.example.com" }
+  "GitHub onPush": { "type": "github.push", "timestamp": "...", "data": { "ref": "refs/heads/main", "commit": "abc123" } },
+  "Filter": { "type": "filter.passed", "timestamp": "...", "data": { "passed": true } },
+  "Deployment": { "type": "deployment.finished", "timestamp": "...", "data": { "status": "success", "url": "https://app.example.com" } }
 }
 ```
 
-From the Deployment node, you can access any upstream output:
+From the Deployment node, you can access any upstream output via `.data`:
 
 ```
-$['GitHub onPush'].ref           // "refs/heads/main"
-$['Filter'].passed               // true
+$['GitHub onPush'].data.ref           // "refs/heads/main"
+$['Filter'].data.passed               // true
 ```
 
 Wrap expressions in `{{ }}` to insert values into text fields; in condition fields (If / Filter) write them bare. Each node also exposes `.config` (resolved settings at run time). See [Expressions](/concepts/expressions).

--- a/src/content/docs/concepts/expressions.md
+++ b/src/content/docs/concepts/expressions.md
@@ -10,9 +10,9 @@ SuperPlane uses [Expr](https://expr-lang.org) for expressions. Expressions let y
 As a run executes, each node's output is added to the message chain. Access it through `$`, referencing nodes by **display name**:
 
 ```
-{{$['Node Name'].field}}
-{{$['Node Name'].nested.field}}
-{{$['Node Name'].array[0].value}}
+{{$['Node Name'].data.field}}
+{{$['Node Name'].data.nested.field}}
+{{$['Node Name'].data.array[0].value}}
 ```
 
 Every entry also includes a **`.config`** property — the node's resolved configuration at run time:
@@ -46,7 +46,7 @@ Expressions appear in two contexts with slightly different syntax:
 **Text fields** (URLs, message bodies, labels) — wrap each expression in `{{ }}`:
 
 ```
-Deployment of {{$['Release'].data.name}} failed. See: {{$['Deploy'].workflow_run.html_url}}
+Deployment of {{$['Release'].data.name}} failed. See: {{$['Deploy'].data.workflow_run.html_url}}
 ```
 
 **Condition fields** (If, Filter) — the entire field is one bare expression that must return `true` or `false`:
@@ -65,7 +65,7 @@ Beyond standard arithmetic (`+`, `-`, `*`, `/`, `%`, `**`) and comparison (`==`,
 
 | Operator | What it does | Example |
 | -------- | ------------ | ------- |
-| `&&` `\|\|` `!` | Logical (aliases: `and`, `or`, `not`) | `{{$['a'].ok && !$['b'].failed}}` |
+| `&&` `\|\|` `!` | Logical (aliases: `and`, `or`, `not`) | `{{$['a'].data.ok && !$['b'].data.failed}}` |
 | `contains` | String contains substring | `{{$['node'].data.body contains "error"}}` |
 | `startsWith` | String prefix check | `{{$['node'].data.ref startsWith "refs/heads/"}}` |
 | `endsWith` | String suffix check | `{{$['node'].data.branch endsWith "-hotfix"}}` |


### PR DESCRIPTION
Update documentation to reflect changes in data structure, replacing `$['Node Name'].field` with `$['Node Name'].data.field` across multiple components and examples for consistency.