### PR TITLE
Docs: warn that unknown fields are rejected (CLI + API)

### DIFF
--- a/src/content/docs/concepts/api-reference.md
+++ b/src/content/docs/concepts/api-reference.md
@@ -3,11 +3,25 @@ title: Public API Reference
 description: Explore the SuperPlane REST API using the interactive Swagger documentation.
 ---
 
+import { Aside } from "@astrojs/starlight/components";
+
 SuperPlane exposes a REST API covering all resources (canvases, integrations, secrets, service accounts, and more). The interactive docs list every route and schema.
 
 The full API reference is available as an interactive Swagger document at:
 
 **[https://app.superplane.com/api/v1/docs](https://app.superplane.com/api/v1/docs)**
+
+<Aside type="caution" title="Strict request validation (unknown fields are errors)">
+API requests are **strictly validated**. If you send a JSON body containing an unrecognized field name, the API returns an error instead of silently ignoring the field.
+
+You should expect an **HTTP 400** response with a JSON body that includes an error `message` similar to:
+
+```json
+{ "code": 3, "message": "unknown field \"hello\"" }
+```
+
+(The exact `message` text may include additional context, but should include `unknown field "..."`.)
+</Aside>
 
 ## Authentication
 

--- a/src/content/docs/concepts/canvas.md
+++ b/src/content/docs/concepts/canvas.md
@@ -3,6 +3,8 @@ title: Canvas
 description: Learn about canvases and how to use the canvas page to design and manage workflows.
 ---
 
+import { Aside } from "@astrojs/starlight/components";
+
 A **canvas** is the workspace where you design and run workflows in SuperPlane. It's a visual
 graph of nodes connected by subscriptions that define how events flow between steps.
 
@@ -50,6 +52,14 @@ Changes are saved automatically, and you can see your workflow update in real-ti
 ### Command Line (CLI)
 
 Use the SuperPlane CLI to manage canvases programmatically:
+
+<Aside type="caution" title="Strict YAML validation (unknown fields are errors)">
+When you update a canvas via YAML, SuperPlane validates the file strictly. **Unknown fields cause an error** (for
+example: typos, deprecated keys, or extra keys produced by automation) instead of being silently ignored.
+
+If you see an error like `unknown field "..."`, check your YAML for unrecognized keys and ensure you’re using the API
+field names (camelCase).
+</Aside>
 
 ```sh
 # Export a canvas

--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -120,6 +120,12 @@ superplane canvases create <canvas_name>
 
 You can also create from a file:
 
+<Aside type="caution" title="Strict YAML validation (unknown fields are errors)">
+Any CLI command that reads a resource from a YAML file (for example `canvases create --file`, `canvases update -f`,
+or `change-requests resolve --file`) validates that YAML strictly. **Unknown fields cause an error** instead of being
+silently ignored.
+</Aside>
+
 ```sh
 superplane canvases create --file my_canvas.yaml
 ```
@@ -149,6 +155,27 @@ This allows you to not have to specify `--canvas-id` on commands that require it
 ### Update a canvas
 
 Export the existing canvas, edit it, then apply your changes:
+
+<Aside type="caution" title="Strict YAML validation (unknown fields are errors)">
+Canvas YAML files are now **strictly validated**. If your YAML contains a field that SuperPlane doesn’t recognize
+(for example a typo, a deprecated key, or an extra key produced by automation), the command will **fail with an
+error** instead of silently ignoring the field.
+
+Example:
+
+```text
+failed to parse canvas yaml: invalid yaml: json: unknown field "hello"
+```
+
+This strict validation applies to any canvas command that reads YAML from a file (for example `canvases create --file`,
+`canvases update -f`, and `canvases change-requests resolve --file`).
+
+Troubleshooting:
+
+- Check for typos (including casing) and deprecated keys.
+- Ensure you are using the **API field names** (camelCase) used in the Canvas YAML example below.
+- If you're generating YAML with automation or coding agents, validate the output before applying it.
+</Aside>
 
 ```sh
 superplane canvases get <canvas_name> > my_canvas.yaml
@@ -324,6 +351,7 @@ Notes:
 - For trigger nodes, use `type: TYPE_TRIGGER` and `trigger.name`.
 - Edge fields are `sourceId`, `targetId`, and optional `channel`.
 - Use `superplane index components` to find component keys (for example, `http`, `if`, `noop`).
+- If you receive an **unknown field** error, check for typos and remove any keys not present in the current API schema.
 - Positioning guideline for agents:
   - Keep downstream nodes on the same row by default (`y` unchanged).
   - Use `x = upstream.x + 480` as the default spacing for new connected nodes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #69

## Summary
- Document strict validation for **Canvas YAML** used by the CLI: unknown fields now fail with an error (instead of being silently ignored).
- Document strict validation for **API request bodies**: unknown JSON fields now return **HTTP 400** with an error message that includes `unknown field "..."`.

## Updated pages
- `src/content/docs/installation/cli.mdx`
- `src/content/docs/concepts/canvas.md`
- `src/content/docs/concepts/api-reference.md`

## Notes
- Examples are intentionally written to match upstream behavior without depending on the full error prefix (which may include extra context).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-106e4d4c-f9f7-49b6-96b3-8ac098042dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-106e4d4c-f9f7-49b6-96b3-8ac098042dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

