### PR TITLE
Docs: remove Group widget references from canvas docs

### DIFF
--- a/src/content/docs/concepts/canvas.md
+++ b/src/content/docs/concepts/canvas.md
@@ -28,7 +28,7 @@ The canvas consists of:
 
 1. **Nodes** — Triggers, components, and [widgets](#widgets). See [Component Nodes](/concepts/component-nodes).
 2. **Connections** — Indicate which node listens to which. See [Data Flow](/concepts/data-flow).
-3. **Add new elements** — Add widgets (annotations, groups) and new components to the canvas.
+3. **Add new elements** — Add widgets (annotations) and new components to the canvas.
 4. **Helper toolbar** — Navigation tools, select/pan mode, search.
 5. **Console** — Warnings, errors, and log of changes and events.
 
@@ -67,9 +67,11 @@ superplane canvases update -f my_canvas.yaml
 **Widgets** are visual-only elements on the canvas. They do not run in the workflow, emit payloads, or connect to subscriptions — they help you document and organize the graph.
 
 - **Annotation** — A sticky note with markdown text (up to 5000 characters) for labels, reminders, or links.
-- **Group** — A labeled frame with optional description and color that groups related nodes visually.
 
-To add an annotation, click the **sticky-note** button in the top-right toolbar. To create a group, select two or more nodes and click the **Group** button in the selection toolbar that appears.
+> **Note**: Visual canvas groups (the "Group" frame element) have been removed. Any saved groups in existing
+> canvases are automatically removed during upgrades.
+
+To add an annotation, click the **sticky-note** button in the top-right toolbar.
 
 ## Versioning
 

--- a/src/content/docs/concepts/component-nodes.md
+++ b/src/content/docs/concepts/component-nodes.md
@@ -7,7 +7,7 @@ description: Learn about components and component nodes, and how to add, configu
 is one instance of a component on the canvas. When you add a component to your canvas, it becomes a
 node that can receive events, perform work, and emit payloads.
 
-**Widgets** are separate: they are visual-only (annotations, groups) and do not run or emit payloads. See [Canvas](/concepts/canvas#widgets).
+**Widgets** are separate: they are visual-only (annotations) and do not run or emit payloads. See [Canvas](/concepts/canvas#widgets).
 
 ## Components vs Component Nodes
 
@@ -39,7 +39,7 @@ perform operations, and emit payloads for downstream nodes.
 
 ### Widgets (non-executable)
 
-**Widgets** are not triggers or actions: they do not subscribe, queue work, or emit payloads. Use them to annotate the canvas or group nodes visually. See [Canvas](/concepts/canvas#widgets).
+**Widgets** are not triggers or actions: they do not subscribe, queue work, or emit payloads. Use them to annotate the canvas visually. See [Canvas](/concepts/canvas#widgets).
 
 ## Adding Component Nodes to the Canvas
 

--- a/src/content/docs/concepts/glossary.md
+++ b/src/content/docs/concepts/glossary.md
@@ -20,7 +20,7 @@ A **node** is a single step on a canvas. Triggers and actions execute; widgets a
 
 ## Widget
 
-A **widget** is a non-executable canvas element (annotation or group) for documentation and layout.
+A **widget** is a non-executable canvas element (annotation) for documentation and layout.
 
 ## Canvas memory
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #70

Group widgets have been removed from the SuperPlane canvas. This PR updates the docs to remove references to the (now unsupported) Group widget/node type and UI steps, and adds a note that existing saved groups are automatically removed during upgrades.

Verification:
- Searched `src/content/docs/` for `group widget`, `group node`, `groupNode`, `type: group`, and `widget type.*group` (no matches)
- Ran `npm run generate:llms`
- Ran `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9512049-91ae-458b-afa2-0b105c442d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9512049-91ae-458b-afa2-0b105c442d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

