### PR TITLE
docs: document rejection of unknown fields (superplane 9c91643)

### DIFF
--- a/src/config/sidebar.mjs
+++ b/src/config/sidebar.mjs
@@ -45,6 +45,10 @@ export const sidebar = [
     ],
   },
   {
+    label: "Reference",
+    items: [{ label: "Canvas YAML", slug: "reference/canvas-yaml" }],
+  },
+  {
     label: "Components",
     autogenerate: { directory: "components" },
   },

--- a/src/content/docs/concepts/api-reference.md
+++ b/src/content/docs/concepts/api-reference.md
@@ -3,6 +3,13 @@ title: Public API Reference
 description: Explore the SuperPlane REST API using the interactive Swagger documentation.
 ---
 
+:::caution[Strict request validation (unknown fields are errors)]
+API requests containing **unknown fields** are rejected with an error response (they are not silently ignored).
+
+This is most useful when you’re building tooling around the API or generating requests with an LLM: a misspelled
+field will fail fast instead of being dropped.
+:::
+
 SuperPlane exposes a REST API covering all resources (canvases, integrations, secrets, service accounts, and more). The interactive docs list every route and schema.
 
 The full API reference is available as an interactive Swagger document at:
@@ -28,6 +35,11 @@ You can obtain a token in two ways:
 curl -s https://app.superplane.com/api/v1/canvases \
   -H "Authorization: Bearer <API_TOKEN>" | jq
 ```
+
+## Errors for unknown fields
+
+If you send a request body with an unrecognized field, SuperPlane returns **`400 Bad Request`** and an error message
+that includes the offending field (for example `unknown field "hello"`).
 
 ## Using with the CLI
 

--- a/src/content/docs/concepts/canvas.md
+++ b/src/content/docs/concepts/canvas.md
@@ -62,6 +62,12 @@ superplane canvases get <canvas_name> > my_canvas.yaml
 superplane canvases update -f my_canvas.yaml
 ```
 
+:::caution[Strict YAML validation (unknown fields are errors)]
+When you update canvases via YAML, SuperPlane rejects **unknown fields** with an error (it does not ignore them).
+If you see an error like `unknown field "hello"`, check for typos and compare your file against
+[Canvas YAML](/reference/canvas-yaml).
+:::
+
 ## Widgets
 
 **Widgets** are visual-only elements on the canvas. They do not run in the workflow, emit payloads, or connect to subscriptions — they help you document and organize the graph.

--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -13,6 +13,12 @@ For agent-first usage of the CLI (auth, canvases, secrets, runs), use the
 `superplane-cli` skill: `npx skills add superplanehq/skills --skill superplane-cli`.
 </Aside>
 
+<Aside type="caution" title="Strict YAML validation (unknown fields are errors)">
+When you run CLI commands that read YAML (for example `canvases create --file` or `canvases update --file`),
+SuperPlane rejects **unknown fields** with an error (it does not ignore them). If you see an error like
+`unknown field "hello"`, check for typos and compare your file against the documented schema.
+</Aside>
+
 ## Installation
 
 Download the latest binary for your operating system and architecture:
@@ -158,6 +164,12 @@ superplane canvases update -f my_canvas.yaml
 
 `superplane canvases update` applies auto layout by default. Use explicit auto-layout flags only when you
 need to control scope or seed nodes.
+
+#### Troubleshooting
+
+- **Error: `unknown field "..."`**: Your YAML contains a key that SuperPlane does not recognize. This is
+  often a typo or a field from an older example. Compare your file to the schema and examples in
+  [Canvas YAML](/reference/canvas-yaml).
 
 #### Check whether versioning is enabled
 

--- a/src/content/docs/reference/canvas-yaml.mdx
+++ b/src/content/docs/reference/canvas-yaml.mdx
@@ -1,0 +1,77 @@
+---
+title: Canvas YAML
+description: Reference for authoring canvas YAML files used by the SuperPlane CLI and API.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+<Aside type="caution" title="Strict validation (unknown fields are errors)">
+Canvas YAML files are parsed strictly. **Unknown fields are rejected with an error** (they are not ignored).
+Typos or extra keys will cause CLI commands like `superplane canvases create --file` / `update --file` to fail.
+</Aside>
+
+This page describes the **shape** of a Canvas YAML file and the most common schema expectations.
+
+For a complete, always-up-to-date schema (including every field), use the interactive API docs linked from
+[Public API Reference](/concepts/api-reference).
+
+## Validation behavior
+
+SuperPlane validates YAML by decoding it into the same request models used by the API.
+
+- **Unknown keys fail fast**: you’ll see an error containing `unknown field "…"`.
+- **API field names apply**: fields in `spec` use **camelCase API names** (for example `sourceId`, not `source_id`).
+
+## Minimal Canvas YAML (example)
+
+```yaml
+apiVersion: v1
+kind: Canvas
+metadata:
+  id: <canvas_id>
+  name: Store app
+spec:
+  edges:
+    - sourceId: schedule-schedule-w3mak1
+      targetId: http-keepalive-ping
+      channel: default
+  nodes:
+    - id: schedule-schedule-w3mak1
+      name: schedule
+      type: TYPE_TRIGGER
+      trigger:
+        name: schedule
+      paused: false
+      position:
+        x: 144
+        y: 0
+      configuration:
+        type: minutes
+        minutesInterval: 1
+        customName: Keepalive {{ now() }}
+    - id: http-keepalive-ping
+      name: http
+      type: TYPE_COMPONENT
+      component:
+        name: http
+      paused: false
+      position:
+        x: 456
+        y: 0
+      configuration:
+        method: GET
+        url: https://store-app-c6nr.examplepaas.com/
+        customName: PaaS keepalive
+```
+
+## Common causes of `unknown field` errors
+
+- **Typos**: for example `targetID` vs `targetId`.
+- **Wrong naming style**: for example `source_id` instead of `sourceId`.
+- **Copying older examples**: fields may have been renamed over time.
+
+If you’re not sure which fields are accepted, export an existing canvas and edit that file:
+
+```sh
+superplane canvases get <canvas_name_or_id> -o yaml > my_canvas.yaml
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #73

## What changed
- Documented strict validation for Canvas YAML and API request bodies: **unknown fields are now rejected with an error** (not silently ignored).

## Docs updates
- Added a dedicated `Canvas YAML` reference page with a strict-validation callout and a short “validation behavior” section.
- Updated the CLI page with a strict YAML validation callout and a troubleshooting entry for `unknown field "..."` errors.
- Updated the Public API Reference page with a strict request validation callout and an errors note (400 Bad Request).

## Verification
- Regenerated LLM context output via `npm run generate:llms` (note: outputs are gitignored in this repo).
- Ran a full site build successfully (`npm run build`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c159fab8-9416-44f9-a51c-699214c0ac52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c159fab8-9416-44f9-a51c-699214c0ac52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

