### PR TITLE
docs: remove canvas group widgets (superplane 01c4032)

### DIFF
--- a/src/content/docs/concepts/canvas.md
+++ b/src/content/docs/concepts/canvas.md
@@ -28,7 +28,7 @@ The canvas consists of:
 
 1. **Nodes** — Triggers, components, and [widgets](#widgets). See [Component Nodes](/concepts/component-nodes).
 2. **Connections** — Indicate which node listens to which. See [Data Flow](/concepts/data-flow).
-3. **Add new elements** — Add widgets (annotations, groups) and new components to the canvas.
+3. **Add new elements** — Add widgets (annotations) and new components to the canvas.
 4. **Helper toolbar** — Navigation tools, select/pan mode, search.
 5. **Console** — Warnings, errors, and log of changes and events.
 
@@ -67,9 +67,8 @@ superplane canvases update -f my_canvas.yaml
 **Widgets** are visual-only elements on the canvas. They do not run in the workflow, emit payloads, or connect to subscriptions — they help you document and organize the graph.
 
 - **Annotation** — A sticky note with markdown text (up to 5000 characters) for labels, reminders, or links.
-- **Group** — A labeled frame with optional description and color that groups related nodes visually.
 
-To add an annotation, click the **sticky-note** button in the top-right toolbar. To create a group, select two or more nodes and click the **Group** button in the selection toolbar that appears.
+To add an annotation, click the **sticky-note** button in the top-right toolbar.
 
 ## Versioning
 

--- a/src/content/docs/concepts/component-nodes.md
+++ b/src/content/docs/concepts/component-nodes.md
@@ -7,7 +7,7 @@ description: Learn about components and component nodes, and how to add, configu
 is one instance of a component on the canvas. When you add a component to your canvas, it becomes a
 node that can receive events, perform work, and emit payloads.
 
-**Widgets** are separate: they are visual-only (annotations, groups) and do not run or emit payloads. See [Canvas](/concepts/canvas#widgets).
+**Widgets** are separate: they are visual-only (annotations) and do not run or emit payloads. See [Canvas](/concepts/canvas#widgets).
 
 ## Components vs Component Nodes
 
@@ -39,7 +39,7 @@ perform operations, and emit payloads for downstream nodes.
 
 ### Widgets (non-executable)
 
-**Widgets** are not triggers or actions: they do not subscribe, queue work, or emit payloads. Use them to annotate the canvas or group nodes visually. See [Canvas](/concepts/canvas#widgets).
+**Widgets** are not triggers or actions: they do not subscribe, queue work, or emit payloads. Use them to annotate the canvas with labels, reminders, or links. See [Canvas](/concepts/canvas#widgets).
 
 ## Adding Component Nodes to the Canvas
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #75

## Summary
- Removed documentation for canvas group widgets (UI elements for visually grouping nodes).
- Updated widgets descriptions to only include annotations.

## Verification
- Full-text search: no remaining canvas group widget/node references.
- `npm run build` succeeds (includes llms generation in prebuild).

Issue: https://github.com/superplanehq/docs/issues/75
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b0a0a79-d2cf-4840-a569-859943b2d8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b0a0a79-d2cf-4840-a569-859943b2d8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

