### PR TITLE
docs: remove group widget references (superplane 01c4032)

### DIFF
--- a/src/content/docs/concepts/canvas.md
+++ b/src/content/docs/concepts/canvas.md
@@ -28,7 +28,7 @@ The canvas consists of:
 
 1. **Nodes** — Triggers, components, and [widgets](#widgets). See [Component Nodes](/concepts/component-nodes).
 2. **Connections** — Indicate which node listens to which. See [Data Flow](/concepts/data-flow).
-3. **Add new elements** — Add widgets (annotations, groups) and new components to the canvas.
+3. **Add new elements** — Add widgets (annotations) and new components to the canvas.
 4. **Helper toolbar** — Navigation tools, select/pan mode, search.
 5. **Console** — Warnings, errors, and log of changes and events.
 
@@ -64,12 +64,11 @@ superplane canvases update -f my_canvas.yaml
 
 ## Widgets
 
-**Widgets** are visual-only elements on the canvas. They do not run in the workflow, emit payloads, or connect to subscriptions — they help you document and organize the graph.
+**Widgets** are visual-only elements on the canvas. They do not run in the workflow, emit payloads, or connect to subscriptions — they help you document the graph.
 
 - **Annotation** — A sticky note with markdown text (up to 5000 characters) for labels, reminders, or links.
-- **Group** — A labeled frame with optional description and color that groups related nodes visually.
 
-To add an annotation, click the **sticky-note** button in the top-right toolbar. To create a group, select two or more nodes and click the **Group** button in the selection toolbar that appears.
+To add an annotation, click the **sticky-note** button in the top-right toolbar.
 
 ## Versioning
 
@@ -128,7 +127,7 @@ The console tracks errors, warnings, and provides a log of all changes and event
 
 ## Best Practices
 
-- **Organize logically**: Group related nodes together visually
+- **Organize logically**: Arrange related nodes near each other
 - **Use clear node names**: Make it easy to understand what each node does
 - **Test incrementally**: Build and test workflows step by step
 - **Monitor the console**: Check for errors and review run history regularly

--- a/src/content/docs/concepts/component-nodes.md
+++ b/src/content/docs/concepts/component-nodes.md
@@ -7,7 +7,7 @@ description: Learn about components and component nodes, and how to add, configu
 is one instance of a component on the canvas. When you add a component to your canvas, it becomes a
 node that can receive events, perform work, and emit payloads.
 
-**Widgets** are separate: they are visual-only (annotations, groups) and do not run or emit payloads. See [Canvas](/concepts/canvas#widgets).
+**Widgets** are separate: they are visual-only (such as annotations) and do not run or emit payloads. See [Canvas](/concepts/canvas#widgets).
 
 ## Components vs Component Nodes
 
@@ -39,7 +39,7 @@ perform operations, and emit payloads for downstream nodes.
 
 ### Widgets (non-executable)
 
-**Widgets** are not triggers or actions: they do not subscribe, queue work, or emit payloads. Use them to annotate the canvas or group nodes visually. See [Canvas](/concepts/canvas#widgets).
+**Widgets** are not triggers or actions: they do not subscribe, queue work, or emit payloads. Use them to annotate the canvas. See [Canvas](/concepts/canvas#widgets).
 
 ## Adding Component Nodes to the Canvas
 

--- a/src/content/docs/concepts/glossary.md
+++ b/src/content/docs/concepts/glossary.md
@@ -20,7 +20,7 @@ A **node** is a single step on a canvas. Triggers and actions execute; widgets a
 
 ## Widget
 
-A **widget** is a non-executable canvas element (annotation or group) for documentation and layout.
+A **widget** is a non-executable canvas element (such as an annotation) for documentation.
 
 ## Canvas memory
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #77

## Summary

Group widgets (the canvas grouping feature) have been removed from SuperPlane
(`superplanehq/superplane@01c4032`). This PR removes all documentation that
describes groups as a widget type so users are not directed toward a feature
that no longer exists.

## Changes

**`src/content/docs/concepts/canvas.md`**
- Removed the **Group** bullet from the Widgets section and the instructions
  for creating groups via the selection toolbar.
- Updated the "Add new elements" list item to no longer mention groups.
- Replaced "Group related nodes together visually" best-practice tip with
  "Arrange related nodes near each other".

**`src/content/docs/concepts/glossary.md`**
- Updated the **Widget** definition to remove "or group".

**`src/content/docs/concepts/component-nodes.md`**
- Removed "groups" from widget descriptions in two places (intro paragraph and
  Widgets subsection).

## Verification

- `npm run build` passes with no errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e3baae-8b08-4342-af51-810e0c392ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e3baae-8b08-4342-af51-810e0c392ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

