### PR TITLE
docs: update versioning and change management docs (superplane 62671f2)

### DIFF
--- a/src/content/docs/concepts/canvas.md
+++ b/src/content/docs/concepts/canvas.md
@@ -73,12 +73,25 @@ To add an annotation, click the **sticky-note** button in the top-right toolbar.
 
 ## Versioning
 
-Canvases are versioned. You edit a draft and publish changes when you're ready to update live.
+Canvases are always versioned. You edit a draft and publish changes when you're ready to update
+the live canvas.
 
-In the UI, versioned canvases expose an **Edit** mode and a **Versioning** view:
+In the UI, canvases expose an **Edit** mode and a **Versioning** view:
 
 1. Enter **Edit** mode to work on your draft.
 2. Use **Versioning** to review your draft and publish it.
+
+### Change management
+
+Change management is an optional layer on top of versioning. When enabled, publishing requires a
+change request to be submitted and approved before changes go live.
+
+- **Change management off** (default): edit your draft and publish directly with the **Publish**
+  button.
+- **Change management on**: edit your draft and submit a change request with the **Propose Change**
+  button. Approvers review and approve the request before it can be published.
+
+Change management can be enabled at the organization level (applies to all canvases) or per canvas.
 
 For CLI commands, see [SuperPlane CLI](/installation/cli).
 

--- a/src/content/docs/concepts/glossary.md
+++ b/src/content/docs/concepts/glossary.md
@@ -22,6 +22,11 @@ A **node** is a single step on a canvas. Triggers and actions execute; widgets a
 
 A **widget** is a non-executable canvas element (annotation or group) for documentation and layout.
 
+## Change management
+
+**Change management** is an optional approval layer for canvas versioning. When enabled, draft changes must be submitted
+as a change request and approved before they can be published. See [Canvas — Change management](/concepts/canvas#change-management).
+
 ## Canvas memory
 
 **Canvas memory** is persistent, canvas-scoped storage for JSON data, organized by namespace. Workflows can read and write it using the memory components. See [Canvas Memory](/concepts/canvas-memory).

--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -159,44 +159,37 @@ superplane canvases update -f my_canvas.yaml
 `superplane canvases update` applies auto layout by default. Use explicit auto-layout flags only when you
 need to control scope or seed nodes.
 
-#### Check whether versioning is enabled
+### Canvas versioning (drafts and publishing)
+
+Canvases are always versioned. Every update writes to a draft, and you publish when ready.
+
+```sh
+# Write changes to your draft version
+superplane canvases update --draft -f my_canvas.yaml
+
+# Publish the draft directly (when change management is off)
+superplane canvases change-requests publish <change-request-id> <canvas_name_or_id>
+```
+
+#### Check whether change management is enabled
 
 Check the canvas metadata directly:
 
 ```sh
-superplane canvases get <canvas_name_or_id> -o json | jq '.metadata.versioningEnabled'
+superplane canvases get <canvas_name_or_id> -o json | jq '.metadata.changeManagementEnabled'
 ```
 
 Expected values:
 
-- `true`: effective versioning enabled for this canvas. Use
-  `superplane canvases update --draft -f ...`, then create a change request.
-- `false`: effective versioning disabled for this canvas. Use `superplane canvases update -f ...` (no `--draft`),
-  and do not use change-request commands.
+- `true`: change management is enabled. After editing a draft, submit a change request for
+  approval before publishing.
+- `false`: change management is disabled. Edit your draft and publish directly.
 
-Quick behavior-based check:
+Change management can be enabled at the organization level (applies to all canvases) or per canvas.
 
-- If `superplane canvases update --draft ...` returns `--draft cannot be used when effective canvas versioning is disabled`,
-  versioning is disabled for this canvas.
-- If `superplane canvases update ...` (without `--draft`) returns
-  `effective canvas versioning is enabled for this canvas; use --draft`,
-  versioning is enabled for this canvas.
-- If `superplane canvases change-requests create ...` returns
-  `effective canvas versioning is disabled for this canvas`,
-  versioning is disabled for this canvas.
+#### Workflow with change management enabled
 
-### Canvas versioning (drafts and change requests)
-
-Canvas update behavior depends on effective canvas mode:
-
-- Organization-level versioning ON forces effective versioning ON for all canvases.
-- Organization-level versioning OFF allows each canvas to toggle versioning independently.
-
-- If canvas versioning is enabled, `superplane canvases update` must use `--draft`.
-- If canvas versioning is disabled, do not use `--draft`; updates apply directly and change requests are not
-  available.
-
-Draft workflow (versioning enabled):
+When change management is enabled, submit a change request from your draft for approval:
 
 ```sh
 # Write changes to your draft version
@@ -219,7 +212,7 @@ If you already set an active canvas with `superplane canvases active <canvas_id>
 
 ### Change request review actions
 
-When versioning is enabled, use `canvases change-requests` to review and publish:
+When change management is enabled, use `canvases change-requests` to review and publish:
 
 ```sh
 # List requests for a canvas (or active canvas)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #79

## Summary

SuperPlane [62671f2](https://github.com/superplanehq/superplane/commit/62671f252985) makes versioning always
enabled and replaces the `versioning_enabled` toggle with a new optional `change_management_enabled` flag.
This PR updates the documentation to reflect those changes.

## Changes

### `src/content/docs/concepts/canvas.md`
- Updated the **Versioning** section to state that versioning is always on (no toggle).
- Added a **Change management** subsection explaining the optional approval layer, the
  Publish vs Propose Change buttons, and org/canvas-level configuration.

### `src/content/docs/installation/cli.mdx`
- Renamed the section to **Canvas versioning (drafts and publishing)** and removed the
  enable/disable versioning checks (versioning is always on, `--draft` is always used).
- Added a **Check whether change management is enabled** subsection with the new
  `changeManagementEnabled` metadata field.
- Added a **Workflow with change management enabled** subsection for the change-request flow.
- Updated the change request review actions intro to reference change management instead of
  versioning.

### `src/content/docs/concepts/glossary.md`
- Added a **Change management** glossary entry.

## Verification

- `npm run build` passes with no errors (72 pages built).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d8a1c4b-2b74-4d9c-bab5-0ca3ac3f2fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d8a1c4b-2b74-4d9c-bab5-0ca3ac3f2fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

