### PR TITLE
docs: document superplane upgrade / self-update CLI command (superplane 248a595)

### DIFF
--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -467,10 +467,21 @@ Delete a queue item:
 superplane queue delete --canvas-id <canvas_id> --node-id <node_id> --item-id <item_id>
 ```
 
-## Updating SuperPlane
+## Updating the CLI
 
-To upgrade to the latest version, download the latest binary and replace
-the existing one:
+If a newer version is available the CLI prints an upgrade notice after
+every command. You can update in place with:
+
+```sh
+superplane upgrade
+```
+
+`superplane self-update` is an alias for the same command. Self-update is
+available on macOS and Linux for release-built binaries; dev builds and
+Windows are not supported.
+
+Alternatively, download the latest binary manually and replace the
+existing one:
 
 ```bash
 curl -L https://install.superplane.com/superplane-cli-darwin-arm64 -o superplane


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #83

## Summary

Documents the new `superplane upgrade` (aliased as `superplane self-update`) CLI command on the existing [SuperPlane CLI](/installation/cli) page.

### What changed

- Renamed the "Updating SuperPlane" section to "Updating the CLI" for clarity.
- Added `superplane upgrade` as the primary upgrade method, noting the `self-update` alias.
- Noted platform support: macOS and Linux release-built binaries only (dev builds and Windows are not supported).
- Mentioned that the CLI automatically prints an upgrade notice when a newer version is available.
- Preserved the manual `curl`-based download method as a fallback.

### Why this scope

The advocate tagged this as `new-content`, but the change is a single new CLI subcommand that fits naturally into the existing CLI page's update section. Adjusted severity to a minor edit — no new page warranted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0651deab-5983-4396-aacd-ec424af06181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0651deab-5983-4396-aacd-ec424af06181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

