### PR TITLE
docs: add `superplane index dump` command to CLI reference (superplane bbfb497)

### DIFF
--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -374,6 +374,19 @@ Describe one trigger:
 superplane index triggers --name <trigger_name>
 ```
 
+Download the full registry (integrations, components, and triggers) to a local JSON file:
+
+```sh
+superplane index dump
+```
+
+By default the file is written to `/tmp/superplane-index.json`. Use `--file` to choose a
+different path:
+
+```sh
+superplane index dump --file registry.json
+```
+
 ## Managing integrations
 
 List connected integrations:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #88

## Summary

Adds documentation for the new `superplane index dump` CLI subcommand to the
existing "Discovery index" section in the CLI reference page (`installation/cli.mdx`).

### What changed

- Documented `superplane index dump` — downloads the full registry (integrations,
  components, and triggers) to a local JSON file.
- Documented the `--file` flag for choosing a custom output path (defaults to
  `/tmp/superplane-index.json`).

### Scope rationale

The automation suggested `new-content` severity, but this is a single new subcommand
under an already-documented command group (`superplane index`). A few lines on the
existing CLI page is sufficient — adjusted down to a minor edit on the existing page.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e6671ff-4e8b-4c8e-886a-a296f1845876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e6671ff-4e8b-4c8e-886a-a296f1845876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

