### PR TITLE
docs: document configurable HMAC signature header for Webhook trigger (superplane 02b7e44)

### DIFF
--- a/src/content/docs/components/Core.mdx
+++ b/src/content/docs/components/Core.mdx
@@ -159,7 +159,9 @@ The Webhook trigger starts a new workflow execution when an HTTP request is rece
 
 ### Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the `X-Signature-256` header
+- **Signature (HMAC)**: Verify requests using an HMAC-SHA256 signature. The **Header** field
+  controls which request header carries the signature (default: `X-Signature-256`). Set it to
+  `X-Hub-Signature-256` when receiving webhooks from GitHub.
 - **Bearer Token**: Require a Bearer token in the `Authorization` header
 - **Header Token**: Require a raw token in a custom header (default: `X-Webhook-Token`)
 - **None (unsafe)**: No authentication (not recommended for production)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #90

The Webhook trigger's Signature (HMAC) authentication now supports a configurable **Header** field
(default `X-Signature-256`). This minor edit updates the HMAC bullet in the Webhook authentication
methods section of `Core.mdx` to:

- Note the Header field is configurable
- State the default (`X-Signature-256`)
- Mention `X-Hub-Signature-256` as the value for GitHub webhooks

No new pages or sections — just a 1–2 sentence expansion of an existing bullet point, matching the
`minor-edit` severity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05b71f9d-3977-47ab-bfdf-f81dff15a86c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05b71f9d-3977-47ab-bfdf-f81dff15a86c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

