### PR TITLE
docs: add GraphQL Request component to Core actions (superplane 6d5fc9d)

### DIFF
--- a/src/content/docs/components/Core.mdx
+++ b/src/content/docs/components/Core.mdx
@@ -23,6 +23,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Approval" href="#approval" description="Collect approvals on events" />
   <LinkCard title="Delete Memory" href="#delete-memory" description="Delete values from canvas memory by namespace and field matches" />
   <LinkCard title="Filter" href="#filter" description="Filter events based on their content" />
+  <LinkCard title="GraphQL Request" href="#graphql-request" description="Send a GraphQL query to an HTTP endpoint" />
   <LinkCard title="HTTP Request" href="#http-request" description="Make HTTP requests" />
   <LinkCard title="If" href="#if" description="Route events based on expression" />
   <LinkCard title="Merge" href="#merge" description="Merge multiple upstream inputs and forward" />
@@ -392,6 +393,67 @@ The expression has access to:
   "data": {},
   "timestamp": "2026-01-16T17:56:16.680755501Z",
   "type": "filter.executed"
+}
+```
+
+<a id="graphql-request"></a>
+
+## GraphQL Request
+
+The GraphQL component sends a GraphQL document to an HTTP endpoint using the standard
+**GraphQL over HTTP** JSON body shape (`POST` with `Content-Type: application/json`).
+
+### Use Cases
+
+- **GraphQL API integration**: Query or mutate data on any GraphQL endpoint
+- **Service orchestration**: Combine GraphQL calls with other workflow steps
+- **Data fetching**: Retrieve structured data from GraphQL services
+
+### Request Configuration
+
+- **URL**: GraphQL HTTP endpoint (supports expressions)
+- **Query**: Multi-line GraphQL document (no JSON escaping needed in the canvas)
+- **Variables**: Optional key/value pairs merged into the request `variables` object
+- **Headers**: Custom HTTP headers to send with the request
+- **Authorization**: Optional bearer token stored in an organization Secret
+- **Success codes**: Comma-separated status codes (e.g. `200, 2xx`). Defaults to `2xx`
+- **Timeout (seconds)**: Request timeout (1–30 s, default 10)
+
+### Output Channels
+
+- **Success**: HTTP status matches the success codes **and** the response body contains no
+  top-level GraphQL `errors` array
+- **Failure**: Non-success HTTP status, a top-level `errors` array is present, or the
+  request could not be completed
+
+### Response Data
+
+The component emits:
+- **status**: HTTP status code
+- **headers**: Response headers
+- **body**: Response body parsed as JSON (falls back to a string if parsing fails)
+
+### Example Output
+
+```json
+{
+  "data": {
+    "body": {
+      "data": {
+        "viewer": {
+          "login": "octocat"
+        }
+      }
+    },
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "status": 200
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "graphql.request.finished"
 }
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #93

## Summary

Adds documentation for the new **GraphQL Request** built-in workflow component on the Core components page (`/components/core`).

SuperPlane commit [6d5fc9d](https://github.com/superplanehq/superplane/commit/6d5fc9d26284791de52f078c37043f1488975910) introduced a native `graphql` action component. This PR mirrors that change in the docs site.

## Changes

**`src/content/docs/components/Core.mdx`**
- Added a `GraphQL Request` LinkCard in the Actions card grid (alphabetically between Filter and HTTP Request)
- Added a new `## GraphQL Request` section documenting:
  - Use cases (GraphQL API integration, service orchestration, data fetching)
  - Request configuration (URL, query, variables, headers, authorization, success codes, timeout)
  - Output channels (Success / Failure) including the GraphQL-errors-on-200 routing behavior
  - Response data shape (`status`, `headers`, `body`)
  - Example output JSON from the upstream `example_output.json`

## Verification

- `npm run build` passes (73 pages built, zero errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3bcb69f-5fa9-422b-8e26-89b4fb824310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3bcb69f-5fa9-422b-8e26-89b4fb824310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

