### PR TITLE
docs: rename component to action in CLI reference (superplane 4add11e)

### DIFF
--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -273,9 +273,9 @@ superplane canvases change-requests resolve <change-request-id> <canvas_name_or_
 
 ### Canvas YAML shape (minimal working example)
 
-When updating canvases via YAML, component nodes and edges must use the API field names.
+When updating canvases via YAML, action nodes and edges must use the API field names.
 
-This example connects a `schedule` trigger to an `http` component that sends a keepalive
+This example connects a `schedule` trigger to an `http` action that sends a keepalive
 request every minute:
 
 ```yaml
@@ -305,8 +305,8 @@ spec:
         customName: Keepalive {{ now() }}
     - id: http-keepalive-ping
       name: http
-      type: TYPE_COMPONENT
-      component:
+      type: TYPE_ACTION
+      action:
         name: http
       paused: false
       position:
@@ -320,10 +320,10 @@ spec:
 
 Notes:
 
-- For component nodes, `type` must be `TYPE_COMPONENT` and `component.name` is required.
+- For action nodes, `type` must be `TYPE_ACTION` and `action.name` is required.
 - For trigger nodes, use `type: TYPE_TRIGGER` and `trigger.name`.
 - Edge fields are `sourceId`, `targetId`, and optional `channel`.
-- Use `superplane index components` to find component keys (for example, `http`, `if`, `noop`).
+- Use `superplane index actions` to find action keys (for example, `http`, `if`, `noop`).
 - Positioning guideline for agents:
   - Keep downstream nodes on the same row by default (`y` unchanged).
   - Use `x = upstream.x + 480` as the default spacing for new connected nodes.
@@ -332,7 +332,7 @@ Notes:
 
 ## Discovery index
 
-Use `index` to discover available integration definitions, triggers, and components.
+Use `index` to discover available integration definitions, triggers, and actions.
 
 ```sh
 superplane index integrations
@@ -344,22 +344,22 @@ Describe one integration definition:
 superplane index integrations --name <integration_name>
 ```
 
-List core components:
+List core actions:
 
 ```sh
-superplane index components
+superplane index actions
 ```
 
-List components from an integration definition:
+List actions from an integration definition:
 
 ```sh
-superplane index components --from <integration_name>
+superplane index actions --from <integration_name>
 ```
 
-Describe one component:
+Describe one action:
 
 ```sh
-superplane index components --name <component_name>
+superplane index actions --name <action_name>
 ```
 
 List triggers from an integration definition:
@@ -374,7 +374,7 @@ Describe one trigger:
 superplane index triggers --name <trigger_name>
 ```
 
-Download the full registry (integrations, components, and triggers) to a local JSON file:
+Download the full registry (integrations, actions, and triggers) to a local JSON file:
 
 ```sh
 superplane index dump


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the CLI reference page (`installation/cli.mdx`) to reflect the breaking API rename
from `component` to `action` introduced in superplanehq/superplane#4399.

### Changes in `cli.mdx`

- **YAML example**: `type: TYPE_COMPONENT` → `type: TYPE_ACTION`, `component:` field → `action:`
- **CLI commands**: `superplane index components` → `superplane index actions` (list, filter by integration, describe)
- **Prose**: Updated references to field names and command names throughout the page

### What was NOT changed (and why)

The conceptual pages (`concepts/component-nodes.md`, `concepts/canvas.md`, `concepts/glossary.md`,
`concepts/data-flow.md`) and integration reference pages (`components/*.mdx`) still use "component"
as a **product/UI concept** (the UI menu is still called "+ Components", the building-block
abstraction is still called a "component"). These are not affected by the API-level rename and
remain correct.

### Verification

- `npm run build` passes cleanly (73 pages built).

Fixes #95
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7b7c0a5-20cb-4954-93db-36b233b46368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7b7c0a5-20cb-4954-93db-36b233b46368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

