### PR TITLE
docs: document HTTP Request Authorization field (superplane 9d17bff)

### DIFF
--- a/src/content/docs/components/Core.mdx
+++ b/src/content/docs/components/Core.mdx
@@ -463,6 +463,11 @@ The HTTP component allows you to make HTTP requests to external APIs and service
 - **Method**: HTTP method to use
 - **Query Parameters**: Optional URL query parameters
 - **Headers**: Custom HTTP headers (header names cannot use expressions)
+- **Authorization** (optional): Authenticate requests using an organization
+  [Secret](/concepts/secrets). Three modes are available:
+  - **Bearer Token**: Sends `Authorization: Bearer <token>` using a secret key
+  - **Basic Auth**: Sends HTTP Basic authentication with a username and a secret-backed password
+  - **Custom Header**: Sets any header (e.g. `X-API-Key`) to a secret-backed value
 - **Body**: Request body in various formats:
   - **JSON**: Structured JSON payload
   - **Form Data**: URL-encoded form data

--- a/src/content/docs/concepts/secrets.md
+++ b/src/content/docs/concepts/secrets.md
@@ -28,7 +28,12 @@ Each secret can contain multiple key-value pairs.
 
 ## Using Secrets in Components
 
-In the **core** component set, organization secrets are used by the **SSH Command** component for authentication (SSH key or password). Select a secret and key from your organization's secrets when configuring SSH.
+In the **core** component set, organization secrets are used by:
+
+- **SSH Command** — authentication via SSH key or password.
+- **HTTP Request** — optional Authorization field (Bearer Token, Basic Auth, or Custom Header).
+
+Select a secret and key from your organization's secrets when configuring these components.
 
 Integrations may store their own credentials separately from organization secrets. If a component supports organization secrets in the future, it will be called out in that component’s documentation.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The HTTP Request component now supports an optional **Authorization** field
backed by organization secrets. This PR documents that change across two pages.

## Changes

**`src/content/docs/components/Core.mdx`** — Added the Authorization bullet to the
HTTP Request "Request Configuration" list, describing the three modes (Bearer Token,
Basic Auth, Custom Header) and linking to the Secrets concept page.

**`src/content/docs/concepts/secrets.md`** — Updated "Using Secrets in Components" to
list HTTP Request alongside SSH Command as a consumer of organization secrets.

## Scope rationale

Automation tagged this `UPDATE:new-content`, but no new page is warranted — the change
adds a single field to an existing component. Adjusted to a minor edit on two existing
pages.

Refs #98
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca2d3f1b-cbb0-4212-9605-bc11513e506e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca2d3f1b-cbb0-4212-9605-bc11513e506e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

