### PR TITLE
docs: add Run Claude Agent action (superplane f6c6d1b)

### DIFF
--- a/src/content/docs/components/Claude.mdx
+++ b/src/content/docs/components/Claude.mdx
@@ -9,12 +9,56 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 ## Actions
 
 <CardGrid>
+  <LinkCard title="Run Claude Agent" href="#run-claude-agent" description="Run a Claude Managed Agent session and wait for it to complete" />
   <LinkCard title="Text Prompt" href="#text-prompt" description="Generate a response using Anthropic's Claude models via the Messages API" />
 </CardGrid>
 
 ## Instructions
 
 To get new Claude API key, go to [platform.claude.com](https://platform.claude.com).
+
+<a id="run-claude-agent"></a>
+
+## Run Claude Agent
+
+The Run Claude Agent component uses
+[Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) to start a
+session with a configured agent and environment, sends your task as a user message, and waits
+until the session reaches a terminal state (`idle` or `terminated`) by polling.
+
+### Prerequisites
+
+- A **Claude API key** configured on the integration.
+- An **agent** and **environment** already created in the Anthropic API or Console. This action
+  references them by ID.
+
+### Configuration
+
+- **Agent ID**: The Managed Agent to run. Uses the latest version unless **Version** is set.
+- **Version** (optional): Pins the session to a specific agent version.
+- **Environment ID**: The environment (container) the session runs in.
+- **Prompt**: The user message (task) sent to the agent.
+- **Vault IDs** (optional): For MCP tools that need vault-backed credentials.
+
+### Output
+
+Emits a finished payload with session **status**, **session ID**, and the final **agent message**
+when available. Downstream steps can branch or consume the result. For failure cases the status is
+still emitted when the session is terminated or the step times out.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "lastMessage": "Finished the requested task.",
+    "sessionId": "sess_01ExampleManagedSession",
+    "status": "idle"
+  },
+  "timestamp": "2026-04-26T12:00:00Z",
+  "type": "claude.runAgent.finished"
+}
+```
 
 <a id="text-prompt"></a>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the new `claude.runAgent` workflow action added in [superplanehq/superplane#4415](https://github.com/superplanehq/superplane/commit/f6c6d1bfb939). This action runs a [Claude Managed Agent](https://platform.claude.com/docs/en/managed-agents/overview) session and waits until it completes.

## Changes

Updated `src/content/docs/components/Claude.mdx`:

- Added **Run Claude Agent** link card to the Actions grid
- Added full **Run Claude Agent** section with:
  - Description of how the action works (session creation, user message, polling)
  - Prerequisites (API key, pre-created agent + environment)
  - Configuration fields: Agent ID, Version, Environment ID, Prompt, Vault IDs
  - Output description (`claude.runAgent.finished` payload)
  - Example output JSON

No new pages were created — the existing Claude component page was extended, matching the pattern used by other component docs (e.g. Cursor's `Launch Cloud Agent`).

## Verification

- `npm run build` passes (73 pages built)
- Content aligned with the upstream superplane internal docs and source code

Fixes #101
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e899068c-ac06-451e-a115-d24b80883f82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e899068c-ac06-451e-a115-d24b80883f82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

