### PR TITLE
docs(cli): note sorted output for `integrations list`

### DIFF
--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -393,6 +393,9 @@ List connected integrations:
 superplane integrations list
 ```
 
+Results are sorted by provider then name, so instances of the same provider
+(e.g. multiple GitHub connections) appear grouped together in a deterministic order.
+
 Get details for one connected integration:
 
 ```sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a one-line note to the CLI reference (`installation/cli.mdx`) documenting that `superplane integrations list` now sorts results by provider then name, grouping instances of the same provider together in deterministic order.

## What changed

- **`src/content/docs/installation/cli.mdx`** — Added a sentence after the `superplane integrations list` code block explaining the sort behavior.

No other hand-written pages show example output or describe the ordering of `integrations list`, so no further changes are needed.

## Context

Tracks [superplane#4426](https://github.com/superplanehq/superplane/commit/7cb15223f792d13f3083c1de63f7d80f68abf2d5) — `fix(cli): sort by provider then name`.

Closes #103
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2526c120-cd17-4b42-9217-4db7fcd015a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2526c120-cd17-4b42-9217-4db7fcd015a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

