### PR TITLE
docs: canvas metadata and change management are now versioned

### DIFF
--- a/src/content/docs/concepts/canvas.md
+++ b/src/content/docs/concepts/canvas.md
@@ -45,7 +45,8 @@ Use the visual editor to build and modify canvases interactively:
 - **Configure nodes**: Click on any node to edit its configuration
 - **Delete elements**: Remove nodes or connections as needed
 
-Changes are saved automatically, and you can see your workflow update in real-time.
+Changes are saved automatically, and you can see your workflow update in real-time. All changes —
+including name, description, and change management settings — go through the versioning system.
 
 ### Command Line (CLI)
 
@@ -73,6 +74,9 @@ To add an annotation, click the **sticky-note** button in the top-right toolbar.
 ## Versioning
 
 Canvases are versioned. You edit a draft and publish changes when you're ready to update live.
+All canvas properties are tracked per version — nodes, edges, name, description, and
+[change management](/installation/cli#canvas-versioning-drafts-and-change-requests) settings.
+Every update produces a versioned change with traceable history.
 
 In the UI, versioned canvases expose an **Edit** mode and a **Versioning** view:
 

--- a/src/content/docs/installation/cli.mdx
+++ b/src/content/docs/installation/cli.mdx
@@ -196,6 +196,11 @@ Canvas update behavior depends on effective canvas mode:
 - If canvas versioning is disabled, do not use `--draft`; updates apply directly and change requests are not
   available.
 
+Change management settings (`changeManagement.enabled` and approver lists) are part of the
+canvas version. Toggling change management on or off goes through the same draft/publish
+flow as any other canvas update. When the live version has change management enabled, all
+updates — including ones that disable it — require `--draft`.
+
 Draft workflow (versioning enabled):
 
 ```sh
@@ -318,6 +323,8 @@ spec:
 
 Notes:
 
+- All fields — `metadata.name`, `metadata.description`, `spec.changeManagement`, nodes, and edges — are
+  versioned together. Changing any of them creates a new version.
 - For action nodes, `type` must be `TYPE_ACTION` and `component` is required.
 - For trigger nodes, use `type: TYPE_TRIGGER` and `component`.
 - Edge fields are `sourceId`, `targetId`, and optional `channel`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates documentation to reflect that canvas metadata (name, description) and change management settings are now stored on versioned canvas versions rather than directly on the canvas record (superplanehq/superplane#4334).

Every canvas update — including metadata and change management changes — now goes through the draft/publish versioning flow.

## Changes

### `src/content/docs/concepts/canvas.md`
- **Editing section**: added note that all changes (name, description, change management) go through versioning
- **Versioning section**: clarified that all canvas properties are tracked per version

### `src/content/docs/installation/cli.mdx`
- **Canvas versioning section**: documented that change management settings are part of the version spec, and toggling them follows the same draft/publish flow
- **Canvas YAML shape notes**: added note that all fields (`metadata.name`, `metadata.description`, `spec.changeManagement`, nodes, edges) are versioned together

## What was NOT changed

- **`concepts/access-control.md`**: no mention of canvas versioning or change management settings — no update needed
- **`concepts/canvas-memory.md`**: unrelated to this change
- **`concepts/api-reference.md`**: points to Swagger docs (auto-generated) — no update needed
- **`concepts/glossary.md`**: no stale definitions affected
- **`components/`**: auto-generated, not touched

Closes #105
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d65f0ad6-4d09-4e93-bf8b-0ba19119396a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d65f0ad6-4d09-4e93-bf8b-0ba19119396a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

