### PR TITLE
docs: explain execution result vs output channel orthogonality

### DIFF
--- a/src/content/docs/concepts/data-flow.md
+++ b/src/content/docs/concepts/data-flow.md
@@ -167,3 +167,18 @@ Subscribe to the `passed` channel to continue on success, or the `failed` channe
 | Merge                   | `success`, `fail`, `timeout` | Routes based on merge outcome               |
 | Dash0 listIssues        | `clear`, `degraded`, `critical` | Routes based on issue severity              |
 | PagerDuty listIncidents | `clear`, `low`, `high`          | Routes based on incident urgency            |
+
+### Execution result vs. output channel
+
+Each execution carries **two independent** outcome fields. They report different things and should not be conflated:
+
+| Field | What it means | Values |
+| --- | --- | --- |
+| `result` | **Runtime health** — did the action run to completion without crashing? | `RESULT_PASSED`, `RESULT_FAILED`, `RESULT_CANCELLED`, `RESULT_UNKNOWN` |
+| `outputs` (keys) | **Semantic routing** — which logical output the action chose | Component-defined channel names (`success`, `failure`, `approved`, `rejected`, `true`, `false`, `not_found`, …) |
+
+**Example.** An HTTP node that receives a `500` status records `result: RESULT_PASSED` (the request was made, the response was parsed, the node finished cleanly) **and** emits on its `failure` channel (the response was a 5xx, so it routed onto the failure output). Both fields are correct.
+
+**Failure-class channels.** Only these channel names — case-insensitive — denote a semantic failure: `failure`, `failed`, `fail`, `timeout`. Other channels such as `rejected` (Approval), `not_found` (Memory), `false` (If), `degraded`, `low`, etc. are normal alternate routing outcomes, not failures.
+
+**Querying "failed runs".** If you want every run that did not take the happy path, filter on **both** axes — `result == RESULT_FAILED` **or** `outputs` contains a key in the failure-class set. `result` alone misses semantic failures routed via channels; channel alone misses runtime crashes that never emitted any output.


### PR DESCRIPTION
## Summary

Adds an `Execution result vs. output channel` subsection to `concepts/data-flow.md`, immediately after the existing `Output Channels` discussion. Covers:

- The two independent fields on every execution: `result` (runtime health) and the keys of `outputs` (semantic routing channel).
- A concrete HTTP-`500` example showing `result: RESULT_PASSED` and `outputs: { failure: [...] }` both populated correctly — and why that is not a bug.
- The closed allow-list of failure-class channel names (`failure`, `failed`, `fail`, `timeout`) and a warning against matching by substring or "sounds negative."
- Guidance for "show me all failed runs" queries: filter on both axes — `result == RESULT_FAILED` **or** `outputs` contains a failure-class key — because either alone misses cases.

## Context

Reported in superplanehq/superplane#4284. An HTTP node receiving a `5xx` records `result=RESULT_PASSED` while routing the payload onto its `failure` output channel. Consumers (and the AI tooling that reads API responses) read this as a contradiction. The data model is correct as designed — the two fields report different things on independent axes — so the fix is documentation rather than a model or proto change.

This page is the highest-leverage surface for the fix because it is referenced from `llms.txt` / `llms-full.txt`, which external AI tools fetch when reasoning about SuperPlane API responses. A companion PR in `superplanehq/skills` adds a one-line pointer in the `superplane-monitor` skill linking to the new anchor.

## Related

- Companion skills PR linking to the new anchor: `superplanehq/skills` PR https://github.com/superplanehq/skills/pull/22 

## Test plan

- [ ] `npm run dev` (or whichever local preview command) → navigate to `/concepts/data-flow#execution-result-vs-output-channel` and confirm the subsection renders, the table is well-formed, and the YAML code block highlights correctly.
- [ ] Confirm the deep-link anchor `#execution-result-vs-output-channel` matches the slug Astro generates for the heading (Astro lowercases and replaces spaces/punctuation with hyphens — heading `### Execution result vs. output channel` should produce that anchor; verify before merging the skills companion PR).
- [ ] After deploy, confirm the new section appears in `[https://docs.superplane.com/llms-full.txt](https://docs.superplane.com/llms-full.txt)`.