### PR TITLE
chore: Console Docs

### DIFF
--- a/src/config/sidebar.mjs
+++ b/src/config/sidebar.mjs
@@ -13,7 +13,15 @@ export const sidebar = [
     items: [
       { label: "Overview", slug: "concepts/superplane-apps" },
       { label: "Canvas", slug: "concepts/canvas" },
-      { label: "Console", slug: "concepts/console" },
+      {
+        label: "Console",
+        items: [
+          { label: "Overview", slug: "concepts/console" },
+          { label: "Widgets", slug: "concepts/console/widgets" },
+          { label: "Data sources", slug: "concepts/console/data-sources" },
+          { label: "Expressions & CEL", slug: "concepts/console/expressions" },
+        ],
+      },
       { label: "Memory", slug: "concepts/canvas-memory" },
       { label: "Files", slug: "concepts/files" },
     ],

--- a/src/content/docs/concepts/console.mdx
+++ b/src/content/docs/concepts/console.mdx
@@ -6,8 +6,10 @@ description: Per-app operational view for status, runbooks, and live workflow da
 import consoleOverview from "../../../assets/console-overview.png";
 import { Image } from "astro:assets";
 
-The **console** is the management console for an app. This is where you
-operate your app, view status, and manage data.
+The **console** is the per-app operational surface. It turns workflow state into an
+at-a-glance view: notes and runbooks, pinned nodes, tables of live data, KPIs, and
+charts. Every app has one console, configured from the UI or from `console.yaml` in
+the app's git repository.
 
 <div class="big-image">
   <figure class="sp-canvas-figure">
@@ -18,38 +20,168 @@ operate your app, view status, and manage data.
   </figure>
 </div>
 
+## When to use a console
+
+The [canvas](/concepts/canvas) shows the graph of nodes and connections — it's where
+you design workflows and debug a specific run. The console answers a different
+question: **what is the state of this system right now?**
+
+Reach for a console when you want:
+
+- **Release dashboards** — current build, last deploy, error rate, and a Run button to
+  promote.
+- **Preview environments** — one row per open pull request, with health status and a
+  Destroy action.
+- **Incident views** — open incidents, active responders, recent runbooks, links to
+  related tools.
+- **Operational status surfaces** — anything where the day-to-day reader cares about
+  outcomes, not topology.
+
+A console belongs to one canvas. Templates do not have editable consoles.
+
 ## How it works
 
-The console is a grid of panels. Each panel can be configured to manage different data sources and display different types of data.
+A console is a **12-column draggable grid**. Each cell holds a **panel** (also called
+a widget) — Markdown notes, pinned nodes, tables, charts, KPIs, or custom HTML.
+Panels read live data from canvas [memory](/concepts/canvas-memory), executions, or
+[runs](/concepts/glossary#run), and re-render as new data lands.
 
-The console is configured by editing the `console.yaml` file in the app's git repository. See [Files](/concepts/files) for more details.
+Open the console from the app header (alongside **Canvas**, **Memory**, and
+**Files**). The canvas graph is hidden while console mode is active, and the panel
+grid takes over the main area.
+
+{/* TODO(image): screenshot of an app with console mode active, header tabs visible */}
 
 ## Editing the console
 
-You can edit the console by clicking the **Edit** button in the top-right corner of the console.
+Click **Edit** in the top-right of the console to enter edit mode. In edit mode you
+can:
 
-In the editor, you can add, remove, and configure panels.
+- **Add panels** from the panel picker.
+- **Move and resize** panels by dragging their header or bottom-right corner.
+- **Configure** a panel by clicking its edit icon — each panel type has its own form.
+- **Delete** panels.
+- **Import / export** the console as YAML.
 
-## Available panels
+{/* TODO(image): screenshot of the console in edit mode with the panel picker open */}
 
-| Panel         | Purpose                                         |
-| ------------- | ----------------------------------------------- |
-| **Markdown**  | Runbooks, notes, and status copy (GFM markdown) |
-| **Table**     | Rows from memory, executions, or runs           |
-| **Chart**     | Bar, stacked bar, line, area, or donut charts   |
-| **Number**    | A single KPI (count, sum, average, and similar) |
-| **Node**      | One pinned node with live status                |
-| **Key Nodes** | Multiple pinned nodes with live status          |
+Changes follow the same **draft and publish** flow as the canvas: edits stay in your
+draft until you publish them. See [Files](/concepts/files) for the underlying YAML
+and how it relates to canvas versioning.
 
-## Data sources
+### Permissions
 
-Data panels read from **memory**, **executions**, or **runs**.
+| Action | Required permission |
+| --- | --- |
+| View the console and export YAML | Canvas read access |
+| Add, move, resize, edit, or delete panels | `canvases:update` |
+| Import YAML | `canvases:update` |
+| Run a node from a node panel or table row action | `canvases:update` |
 
-- **Memory** — JSON data from the app's memory. See [Memory](/concepts/canvas-memory).
-- **Executions** — Execution history from the app's executions.
-- **Runs** — Run history from the app's runs.
+Read-only viewers see the console and can export the YAML, but the **Edit** button
+and any runtime Run buttons are disabled with a tooltip explaining why. Server-side
+authorization is the source of truth — UI state mirrors it.
 
-## Best practices
+## Panel types at a glance
 
-- Combine panels to create a dashboard that provides a holistic view of your app's status and data.
-- Use AI agents to generate the console panels and data sources.
+The console ships with seven panel types. See [Widgets](/concepts/console/widgets)
+for the full reference.
+
+| Panel | Purpose |
+| --- | --- |
+| **Markdown** | Notes, runbooks, and status copy with GitHub-flavored markdown and live variables. |
+| **HTML** | Custom HTML with scoped `<style>` blocks and a Tailwind utility safelist. |
+| **Node** | Pin one canvas node with live status and an optional Run button. |
+| **Key Nodes** | Pin several nodes in one card with short purpose lines. |
+| **Table** | Render rows from memory, executions, or runs, with filters and row actions. |
+| **Chart** | Bar, stacked-bar, line, area, or donut chart over the same data sources. |
+| **Number** | One KPI, several KPIs side-by-side, or an aggregate combined across namespaces. |
+
+Tables, charts, and numbers all draw from the same three [data
+sources](/concepts/console/data-sources): **memory**, **executions**, and **runs**.
+
+## `console.yaml`
+
+Every console is stored as YAML. You can edit it from the UI, or from the **Files**
+tab as `console.yaml` in the app's git repository. The canonical shape is:
+
+```yaml
+apiVersion: v1
+kind: Console
+metadata:
+  canvasId: 00000000-0000-0000-0000-000000000000
+  name: Example canvas
+spec:
+  panels:
+    - id: envs
+      type: table
+      content:
+        dataSource:
+          kind: memory
+          namespace: environments
+        render:
+          kind: table
+          columns:
+            - field: service
+              label: Service
+  layout:
+    - i: envs
+      x: 0
+      y: 0
+      w: 12
+      h: 6
+```
+
+Two top-level lists drive everything:
+
+- `spec.panels[]` — the panel definitions. Each panel has an `id`, a `type`, and a
+  typed `content` object. Panel types and their content shapes are documented in
+  [Widgets](/concepts/console/widgets).
+- `spec.layout[]` — the grid placement for each panel. The `i` field references a
+  panel `id`; `x` and `y` are column/row positions, `w` and `h` are the width and
+  height in grid units.
+
+### Rules
+
+- `apiVersion` must be `v1`.
+- `kind` must be `Console`.
+- Unknown top-level, metadata, panel, or layout fields are rejected.
+- `metadata.canvasId` and `metadata.name` are informational on export.
+- Missing `spec.panels` or `spec.layout` means an empty list.
+- Maximum panel count is **50**.
+- Maximum panel payload size is **1 MiB**.
+
+## Importing and exporting
+
+Export is available to everyone with read access — open **Edit** mode and use the
+YAML modal, or pull the file from the **Files** tab.
+
+**Import is replace-all.** When you import a YAML file, every panel and every layout
+item is replaced in a single update. There is no merge, no patch, and no per-panel
+import.
+
+## Bundling a console with an installable app
+
+Apps installed from a public GitHub repository can ship an optional `console.yaml`
+alongside `canvas.yaml`. When present, the install flow reads both files from the
+same ref and writes the console into the new canvas.
+
+- The file lives at `console.yaml` in the repo root, on the same branch as
+  `canvas.yaml` (typically `main` or `master`).
+- It uses the same `apiVersion: v1`, `kind: Console` shape documented above.
+- A malformed file aborts the install before any canvas is created — fix the YAML
+  and re-run install.
+- A missing file is fine. The new canvas starts with an empty console you can fill
+  in later.
+- `metadata.canvasId` is ignored on install. The panels and layout become the new
+  canvas's full console.
+
+## Where to go next
+
+- [Widgets](/concepts/console/widgets) — every panel type, its configuration fields,
+  and a YAML example.
+- [Data sources](/concepts/console/data-sources) — `memory`, `executions`, and
+  `runs`, plus the markdown / HTML **variable** system.
+- [Expressions & CEL](/concepts/console/expressions) — how console expressions
+  differ from canvas [Expr](/concepts/expressions), with the full CEL builtins
+  catalog.

--- a/src/content/docs/concepts/console/data-sources.mdx
+++ b/src/content/docs/concepts/console/data-sources.mdx
@@ -1,0 +1,349 @@
+---
+title: Data sources
+description: The three console data sources — memory, executions, and runs — plus the variable system that powers markdown and HTML widgets.
+---
+
+Console widgets that show live data — [tables, charts,
+numbers](/concepts/console/widgets), and the variables embedded in markdown and
+HTML widgets — all read from the same three **data sources**: `memory`,
+`executions`, and `runs`.
+
+This page covers the shape of each source, what fields are available, how to
+address per-node outputs across a run, and how to declare named variables for
+prose widgets.
+
+## At a glance
+
+| Source | Best for | What it returns |
+| --- | --- | --- |
+| [`memory`](#memory) | Long-lived facts: open PRs, environments, incidents, costs. | Rows from a canvas [memory](/concepts/canvas-memory) namespace. |
+| [`executions`](#executions) | Per-node history: every run of "Deploy", every webhook fire. | Flattened execution rows, optionally filtered to one node. |
+| [`runs`](#runs) | End-to-end runs: workflow-level dashboards, run-level KPIs. | Run rows with the initial trigger payload and per-node outputs. |
+
+All three are valid for the `dataSource` field on table, chart, and number
+widgets. The `memory` and `run` shapes also drive the [variable
+system](#variables).
+
+## Memory
+
+The `memory` source reads rows from a canvas memory namespace. Memory is
+persistent JSON storage scoped to the app — see [Memory](/concepts/canvas-memory)
+for how it's written.
+
+```ts
+{
+  kind: "memory",
+  namespace: string,
+  fieldPath?: string,
+}
+```
+
+- `namespace` — the memory namespace to read from. The editor suggests
+  namespaces it sees in live memory.
+- `fieldPath` — optional dot path that flattens a nested value or list. Useful
+  when a row stores `{ items: [...] }` and you want one row per item rather than
+  one row per memory entry.
+
+Each row exposes the JSON it was stored with, plus the memory metadata: `id`,
+`namespace`, `createdAt`, and `updatedAt`.
+
+### Use case
+
+A memory-backed table is the recommended pattern for ephemeral-environment
+consoles — one row per pull request, one row per preview, one row per incident.
+Writes from the workflow (via memory components) show up in the console on the
+next render.
+
+## Executions
+
+The `executions` source returns one row per node execution. Use it when you care
+about per-step history rather than end-to-end runs.
+
+```ts
+{
+  kind: "executions",
+  node?: string,
+  limit?: number,
+}
+```
+
+- `node` — optional node id or name. When set, only executions of that node are
+  returned.
+- `limit` — number of execution rows to fetch.
+
+Execution widgets eager-load extra event pages until they reach the configured
+`limit` or hit a bounded page cap. This avoids count widgets flashing an
+intermediate value when the first event page has few executions.
+
+### Row shape
+
+| Field | Meaning |
+| --- | --- |
+| `status` | Normalized status (`passed`, `failed`, `running`, `pending`, …). |
+| `nodeName` | Display name of the executing node. |
+| `durationMs` | How long the execution took, in **milliseconds**. Pair with `format: duration`. |
+| `payload` | The data the node received from its root event. |
+| `state` | Raw execution state. |
+| `result` | Raw execution result. |
+| `resultReason` | Reason code when the result is set. |
+| `resultMessage` | Human-readable result message. |
+| `id` | Execution id. |
+| `nodeId` | Internal node id. |
+| `canvasId` | Canvas id. |
+| `parentExecutionId` | Parent execution id, when this row is a child execution. |
+| `previousExecutionId` | Previous execution id in the chain. |
+| `createdAt` / `updatedAt` | Timestamps in ISO-8601. |
+
+## Runs
+
+The `runs` source returns one row per run — an end-to-end workflow execution
+from the initial trigger through every downstream node. Use it for run-level
+dashboards (deploys per day, runs per service, cost per workflow).
+
+```ts
+{
+  kind: "runs",
+  limit?: number,
+}
+```
+
+- `limit` — number of run rows to fetch. Number widgets can use the API's
+  `totalCount` for count KPIs without loading every row.
+
+### Row shape
+
+Run rows include the raw run object plus a set of derived fields the console
+adds for ergonomics:
+
+| Field | Meaning |
+| --- | --- |
+| `status` | Normalized run status (`passed`, `failed`, `cancelled`, `running`, `unknown`). |
+| `state` | Raw run state. |
+| `result` | Raw run result. |
+| `nodeName` | Display name of the node that initiated the run (resolved from `rootEvent.nodeId`). |
+| `payload` | Alias for `rootEvent.data` — the initial payload that started the run. |
+| `durationMs` | Created-to-finished elapsed time in **milliseconds**. Pair with `format: duration`. |
+| `$` | Map of per-node outputs keyed by node display name. See [Addressing per-node outputs](#addressing-per-node-outputs). |
+| `id` | Run id. |
+| `canvasId` | Canvas id. |
+| `versionId` | Canvas version id this run executed against. |
+| `createdAt` / `updatedAt` / `finishedAt` | Timestamps in ISO-8601. |
+| `rootEvent.nodeId` | Internal node id of the root trigger. |
+| `rootEvent.customName` | Custom name attached to the root event, when set. |
+
+## Field catalogs
+
+The table editor populates column dropdowns, filter / sort field datalists, and
+row-action payload chips from a **field catalog** derived from the data source.
+
+| Data source | Field catalog |
+| --- | --- |
+| `memory` | Discovered live from canvas memory entries in the chosen namespace. |
+| `executions` | Static catalog matching the execution row shape above. |
+| `runs` | Static catalog matching the run row shape above, including the derived fields and `$`. |
+
+When suggestions are available, the column header bar exposes an **Add all
+fields** button and quick-add chips. Each chip inserts a column with a sensible
+default `format` (for example `status` → `status`, `createdAt` → `relative`).
+
+The column, filter, row-style, and sort field inputs are free text — type any
+nested dot path (`payload.user_id`, `rootEvent.customName`) or `{{ CEL }}`
+template. Catalog entries surface as autocomplete suggestions, and when the
+typed value matches a known catalog field the column's `label` and `format`
+autofill (only when the author hasn't already set them).
+
+## Addressing per-node outputs
+
+The `runs` source exposes a `$` map keyed by **node display name**, so widgets
+can address the outputs of any node within that run. The shape mirrors the
+canvas-side expression syntax (`$['Node Name'].data` — see
+[Expressions](/concepts/expressions)).
+
+| Path | Resolves to |
+| --- | --- |
+| `$["deploy-prod"].outputs` | The raw outputs map (`{ channel: [event, ...] }`) for that node's execution. |
+| `$["deploy-prod"].outputs.default[0]` | The first event emitted on the `default` channel. |
+| `$["deploy-prod"].data` | Convenience shortcut for the **last** event on the `default` channel (or the first available channel), with one `data` envelope unwrapped. Matches what canvas-side `$['Node'].data` resolves to. |
+| `$["deploy-prod"].state` | Raw per-node state. Useful for row styling. |
+| `$["deploy-prod"].result` | Raw per-node result. Useful for row styling. |
+
+The same syntax works in literal field paths and in `{{ CEL }}` templates:
+
+```yaml
+columns:
+  - field: $["deploy-prod"].data.url
+    label: URL
+    format: link
+  - field: '{{ $["deploy-prod"].data.url }}'
+    label: URL (template form)
+    format: link
+```
+
+**Missing nodes resolve to `undefined`.** When a given node didn't run for a row
+(the workflow forked and only one branch executed, or the run hasn't reached
+that node yet), `$["other-node"].outputs` returns `undefined` and the widget
+cell renders as `-`. This is intentional and matches how missing dot paths
+behave elsewhere.
+
+### Performance note
+
+Run-level outputs are not part of the initial `runs` payload — executions come
+back as lightweight references. The widget side-loads outputs for each visible
+run, capped by the panel's `limit`. The response is cached per `(canvas, run)`,
+so the same data backs the widget and the run detail modal.
+
+Widgets with very large `limit` values issue one extra request per run on first
+load.
+
+## Durations
+
+`durationMs` is **always milliseconds**, on both execution rows and run rows.
+Pair it with `format: duration` to render `5m 30s` style values:
+
+```yaml
+columns:
+  - field: durationMs
+    label: Duration
+    format: duration
+```
+
+Watch out for two pitfalls:
+
+- `format: duration` always reads its input as milliseconds. If your source
+  emits seconds, convert with CEL first: `{{ value * 1000 }}`.
+- `field: finishedAt - createdAt` does **not** work directly. Both timestamps
+  are ISO-8601 strings, and CEL does not subtract strings. Either use the
+  derived `durationMs`, or compute it explicitly with `epochMs` — see
+  [Expressions: durations](/concepts/console/expressions#durations).
+
+## Variables
+
+[Markdown](/concepts/console/widgets#markdown) and
+[HTML](/concepts/console/widgets#html) widgets don't have a `dataSource`
+themselves. Instead, they declare named **variables** that resolve from `memory`
+or `runs`, and then reference them in the body or title with `{{ }}`
+templates:
+
+```yaml
+- id: deploy-summary
+  type: markdown
+  content:
+    title: "Latest deploy of {{ release.service }}"
+    body: |
+      ## {{ release.service }}
+
+      - Status: **{{ lastRun.status }}**
+      - Triggered by: {{ lastRun.nodeName }}
+      - Output URL: {{ lastRun.$["Deploy"].data.url }}
+    variables:
+      - name: release
+        source:
+          kind: memory
+          namespace: releases
+          orderBy: createdAt
+          direction: desc
+          matches:
+            - field: env
+              value: production
+      - name: lastRun
+        source:
+          kind: run
+          select: latest_passed
+```
+
+Variables resolve to `null` when no row matches (or `[]` in [list
+mode](#list-mode)). CEL access on `null` renders as an empty string, so a
+partial template never throws.
+
+The in-card editor surfaces a per-variable preview with one-click **insert**
+buttons, plus a live rendered preview that mirrors what the saved panel will
+display.
+
+### Source kinds
+
+Two source kinds are supported.
+
+#### `memory`
+
+Picks the first row from a memory namespace (default), or the full sorted array
+when `mode: list` is set. The exposed object spreads the memory row's `values`
+together with `id`, `namespace`, `createdAt`, and `updatedAt`.
+
+| Field | Meaning |
+| --- | --- |
+| `namespace` | Memory namespace. Required. |
+| `matches` | Optional list of `{ field, value }` filters. AND-combined. The namespace `id` is queryable here too. |
+| `orderBy` | Sort key. Defaults to `createdAt`. |
+| `direction` | `asc` or `desc`. Defaults to `desc` (most recent first). |
+| `mode` | `single` (default) or `list`. See [List mode](#list-mode). |
+| `limit` | Positive integer cap when `mode: list` is set. |
+
+#### `run`
+
+Picks the most recent run matching a selector.
+
+| Field | Meaning |
+| --- | --- |
+| `select` | `latest`, `latest_passed`, or `latest_failed`. |
+
+The exposed object spreads the run row and adds the same convenience fields the
+table widget surfaces:
+
+- `status` — normalized to `passed | failed | cancelled | running | unknown`.
+- `nodeName`, `payload`, `durationMs`.
+- `$` — the per-node outputs map. Use it as
+  `{{ run.$["Node Name"].data.field }}` for run-level output references.
+
+`run` variables always resolve to a single row in this iteration. To iterate
+over runs, use `mode: list` on a memory namespace instead.
+
+### List mode
+
+Add `mode: list` to a memory source to resolve the variable to **every matching
+row** instead of just the first. This unlocks CEL list macros (`map`, `filter`,
+`all`, `exists`, `size`) inside `{{ }}` so authors can render the rows as a
+markdown / HTML list, count or filter them inline, etc. An optional `limit`
+(positive integer) caps the array; omit it to include every match.
+
+```yaml
+variables:
+  - name: deploys
+    source:
+      kind: memory
+      namespace: deployments
+      orderBy: createdAt
+      direction: desc
+      mode: list
+      limit: 20
+```
+
+A bare `{{ deploys }}` renders the array as JSON for inspection — useful when
+you're still figuring out the shape. To splice a mapped list into the output,
+wrap it in `join(list, sep)`:
+
+```markdown
+- Total deploys: {{ size(deploys) }}
+- Passed: {{ size(deploys.filter(d, d.status == "passed")) }}
+
+{{ join(deploys.map(d, "- " + d.name + " @ " + d.createdAt), "\n") }}
+```
+
+For HTML widgets, use `""` as the separator for seamless concatenation:
+
+```html
+<div>{{ join(deploys.map(d, "<p>" + d.name + "</p>"), "") }}</div>
+```
+
+cel-js does not allow `.method()` postfix after a function-call result, so chain
+macros directly off the bound variable (`deploys.filter(...).map(...)`) rather
+than after a parenthesized call. See [Expressions:
+limitations](/concepts/console/expressions#limitations) for the broader
+constraint.
+
+## Where to go next
+
+- [Widgets](/concepts/console/widgets) — every panel type and its content
+  fields.
+- [Expressions & CEL](/concepts/console/expressions) — `{{ }}` templates, the
+  full builtins catalog, and the differences from canvas
+  [Expr](/concepts/expressions).

--- a/src/content/docs/concepts/console/expressions.mdx
+++ b/src/content/docs/concepts/console/expressions.mdx
@@ -1,0 +1,259 @@
+---
+title: Expressions and CEL
+description: How console expressions differ from canvas expressions, the CEL builtins available to widgets, and the limitations to watch for.
+---
+
+The [console](/concepts/console) and the [canvas](/concepts/canvas) both let you
+weave live data into configuration with `{{ }}` templates — but they use
+different expression languages under the hood. This page explains the
+differences, the CEL builtins available to console widgets, and the limitations
+to watch for when authoring widget configuration.
+
+## Console CEL vs canvas Expr
+
+Canvas nodes evaluate expressions with [Expr](https://expr-lang.org)
+(`expr-lang`). Console widgets evaluate expressions with **CEL** ([Common
+Expression Language](https://github.com/google/cel-spec)) via `cel-js`. The two
+languages look alike for most everyday cases, but they have different syntax,
+different builtins, and different data in scope.
+
+| Aspect | Canvas (Expr) | Console widgets (CEL) |
+| --- | --- | --- |
+| Engine | `expr-lang` (Go) | `cel-js` (browser) |
+| Template syntax | `{{ ... }}` in text fields; bare expression in condition fields. | `{{ ... }}` everywhere — column `field`, `label`, `href`, row-action `payload` / `confirm`, markdown / HTML body, etc. |
+| Per-row data | N/A — runs are evaluated server-side. | Row fields are top-level identifiers (e.g. `status`, `payload.user_id`). |
+| Time helper | `now()` returns a date value. | `now` is a top-level identifier — **Unix seconds** as an integer. |
+| Per-node outputs | `$['Node'].data.field` | `$["Node"].data.field`, `.outputs`, `.state`, `.result` — see [data sources](/concepts/console/data-sources#addressing-per-node-outputs). |
+| Closures | `filter(items, # > 10)` with `#` for the current element, `#acc` for the accumulator. | List macros: `items.filter(x, x > 10)`, `items.map(x, x.name)`, `items.exists(x, ...)`, `items.all(x, ...)`, `size(items)`. |
+| String contains | `s contains "x"` | `contains(s, "x")` — see [Builtins](#builtins). |
+| Regex match | `s matches "..."` | `matches(s, "...")` |
+| Membership | `"prod" in items` | Iterate with a macro: `items.exists(x, x == "prod")`. |
+| Nil coalescing | `value ?? "default"` | No `??`. Use a ternary: `value != null ? value : "default"`. |
+| Ternary | `cond ? a : b` | `cond ? a : b` |
+| Optional chaining | `data?.user?.name` | No `?.`. Guard with conditionals or with safe traversal. |
+
+For the canvas-side reference, see [Expressions](/concepts/expressions) and
+[Expression functions](/concepts/expression-functions).
+
+## Where each language runs
+
+Console widgets accept CEL in two related styles:
+
+- **`{{ CEL }}` templates** — anywhere a string is rendered: column `field` and
+  `label`, row-action `payload` and `confirm` text, markdown and HTML widget
+  bodies, panel titles. Use these for interpolation and rich expressions.
+- **Legacy bare expressions** — supported in `show` (row visibility, cell
+  visibility, action visibility) and inside some filters. Authors can still
+  write `status == "running"` without wrapping it in `{{ }}`.
+
+Use structured `where` filters when the condition is simple enough to validate
+ahead of time. Use `{{ CEL }}` when you need expression power.
+
+```yaml
+columns:
+  - field: pr_number
+    label: PR
+  - field: '{{ "PR #" + string(pr_number) }}'
+    label: PR label
+    show: 'status != "destroyed"'
+where:
+  - field: status
+    op: neq
+    value: destroyed
+```
+
+## The row environment
+
+Inside a `{{ ... }}` template, every field on the current row is a top-level
+identifier. With a `runs` row, for example, `status`, `nodeName`, `payload`,
+`durationMs`, `$`, and the rest are addressable directly.
+
+Two additional identifiers are always available:
+
+- `now` — current time as **Unix seconds** (integer). Use `now * 1000` when you
+  need milliseconds, or pair with `epochMs` for arithmetic on timestamp fields.
+- `$` — the per-node outputs map for the current run row. See [Addressing
+  per-node outputs](/concepts/console/data-sources#addressing-per-node-outputs).
+
+The CEL compiler internally rewrites `$` to a safe identifier (cel-js does not
+accept `$` as an identifier on its own), but authors don't need to be aware of
+the rewrite. String literals are preserved verbatim, so a `$` inside `"..."` or
+`'...'` is left alone.
+
+## Builtins
+
+In addition to the standard CEL operators and macros (`map`, `filter`, `all`,
+`exists`, `size`, etc.), the console exposes these helpers in every
+expression's environment:
+
+### Type coercions
+
+| Function | Returns |
+| --- | --- |
+| `int(v)` | Integer coercion. Sensible fallbacks for nullish input. |
+| `float(v)` | Float coercion. |
+| `string(v)` | String coercion. |
+
+### Strings and regex
+
+| Function | Returns |
+| --- | --- |
+| `contains(s, sub)` | `true` when `s` contains `sub`. |
+| `startsWith(s, p)` | `true` when `s` starts with `p`. |
+| `endsWith(s, p)` | `true` when `s` ends with `p`. |
+| `matches(s, regex)` | `true` when `regex` matches `s`. |
+| `lower(s)` | Lowercased copy. |
+| `upper(s)` | Uppercased copy. |
+| `trim(s, chars?)` | Strip leading / trailing whitespace, or — when `chars` is supplied — characters that appear in `chars`. |
+| `replace(s, old, new)` | Replace every occurrence of `old` with `new`. Empty `old` returns `s` unchanged. |
+| `indexOf(s, sub)` | First index of `sub` in `s`, or `-1` when missing. |
+
+### Truncating long strings
+
+These all return a scalar — see [Limitations](#limitations) for why.
+
+| Function | Returns |
+| --- | --- |
+| `firstLine(s)` | Text before the first line break. Treats `\r\n` and bare `\r` the same as `\n`. Returns `""` for `null`/`undefined`. Use it to keep multi-line run outputs from blowing up table cells: `{{ firstLine(payload.message) }}`. |
+| `substring(s, start, end?)` | Slice from `start` (inclusive) to `end` (exclusive). When `end` is omitted, returns everything from `start` onward. Negative `start` counts from the end (`-3` = last 3). Indices are clamped to the string length, and `end <= start` returns `""`. |
+| `truncate(s, n, suffix?)` | First `n` characters, with `suffix` appended only when truncation actually happened. Use it for "show first 80 chars with `…`" cells: `{{ truncate(payload.message, 80, "…") }}`. |
+| `splitIndex(s, sep, i)` | Nth segment of `split(s, sep)`. Negative `i` counts from the end (`-1` = last). Returns `""` for out-of-range / non-numeric `i`. The separator is unescaped (`\n`, `\r`, `\t`, `\\`). A `"\n"` separator also matches `\r\n` and bare `\r`, so it agrees with `firstLine` on Windows line endings. |
+
+### Dates and durations
+
+| Function | Returns |
+| --- | --- |
+| `duration(seconds)` | Format a number of seconds as `5m 30s` / `1h 5m`. |
+| `timestamp(seconds)` | Format epoch seconds as an ISO-8601 string. |
+| `formatDate(value, pattern)` | Render any date-like value (ISO string, Date, epoch number) with tokens `yyyy yy MM M dd d HH H mm m ss s`. Renders in the viewer's local time. |
+| `epochMs(value)` | Convert any date-like value (ISO-8601 string, Date instance, epoch seconds, epoch ms) to **milliseconds since epoch**. Returns `0` for unparseable input so arithmetic stays defined. |
+
+### Structural
+
+| Function | Returns |
+| --- | --- |
+| `parseJson(s)` | Parse a JSON-encoded string into a structured value (list, map, scalar). Non-string inputs pass through unchanged; invalid JSON or `null` input returns `null`. |
+| `join(list, sep)` | Concatenate the elements of a list into a string with an explicit separator. Non-array `list` returns `""`; non-string `sep` collapses to `""`; `null`/`undefined` elements render as `""`. |
+
+## Common patterns
+
+**Truncating a multi-line payload field for a table cell:**
+
+```yaml
+columns:
+  - field: '{{ firstLine(payload.message) }}'
+    label: Message
+  - field: '{{ truncate(payload.message, 80, "…") }}'
+    label: Message (single line)
+```
+
+**Conditional badge label:**
+
+```yaml
+columns:
+  - field: '{{ status == "passed" ? "OK" : status }}'
+    label: Status
+    format: badge
+```
+
+**Splicing a list of memory rows into markdown:**
+
+```markdown
+{{ join(deploys.map(d, "- " + d.name + " @ " + d.createdAt), "\n") }}
+```
+
+**Cost summary with a fallback:**
+
+```yaml
+columns:
+  - field: '{{ cost != null ? cost : 0 }}'
+    label: Cost
+    format: number
+```
+
+## Durations
+
+`format: duration` always interprets its input as **milliseconds**. The most
+common pitfall on console widgets is trying to subtract two ISO-8601 timestamps
+directly — CEL does not subtract strings. Pick the form that fits your data:
+
+- **Use the derived `durationMs` field** — easiest for the standard "how long
+  did this take" cell on `runs` or `executions` rows. The field is already
+  there:
+
+  ```yaml
+  - field: durationMs
+    label: Duration
+    format: duration
+  ```
+
+- **Compute it explicitly in CEL** when you're comparing arbitrary timestamp
+  fields (e.g. trigger time vs finish time):
+
+  ```yaml
+  - field: '{{ duration((epochMs(finishedAt) - epochMs(createdAt)) / 1000) }}'
+    label: Duration
+  ```
+
+- **Render the raw ms** when you want the column formatter to do the formatting
+  and downstream filters to compare against a number:
+
+  ```yaml
+  - field: '{{ epochMs(finishedAt) - epochMs(createdAt) }}'
+    label: Duration
+    format: duration
+  ```
+
+When the underlying data is in seconds, multiply by `1000` before passing it
+in: `{{ value * 1000 }}`.
+
+## Limitations
+
+### No postfix after a function-call result
+
+cel-js does not support postfix `.field`, `[i]`, or `.method(...)` after a
+function-call result. Expressions like `parseJson(blob).items[0].id` or
+`parseJson(tags).map(t, t)` will fail to parse.
+
+To work around it:
+
+- **Iterate or dot-access parsed data** by shaping it as a real list/map
+  upstream. Canvas memory values are JSON-typed, so storing
+  `{"tags": ["a","b"]}` lets you write `tags.map(t, t)` natively.
+- **Compose with macros** that take the parsed value as an argument: `size`,
+  `string`, etc.
+
+The string-trimming helpers (`firstLine`, `substring`, `truncate`,
+`splitIndex`) all return scalars for the same reason — authors can't write
+`split(s, "\n")[0]` or `s.substring(0, 80)` against cel-js. The single-call
+form (`firstLine(s)`, `substring(s, 0, 80)`) sidesteps the parser limitation.
+
+Equivalent expressions like `value[:80]` work in expr-lang at node-config /
+write time, but **not** in widget cells.
+
+### No `??` or `?.`
+
+CEL does not have nil-coalescing (`??`) or optional chaining (`?.`). Use a
+ternary when you need a fallback:
+
+```yaml
+field: '{{ name != null ? name : "unknown" }}'
+```
+
+### `$` rewrite
+
+The CEL compiler rewrites `$` to a safe identifier internally because cel-js
+does not accept `$` as a top-level identifier. This is transparent to authors —
+write `$["Deploy"].data.url` and it works the same way it does on the canvas
+side. String literals are preserved verbatim, so a `$` inside `"..."` or `'...'`
+is left alone.
+
+## Where to go next
+
+- [Widgets](/concepts/console/widgets) — every panel type and where templates
+  show up in their content.
+- [Data sources](/concepts/console/data-sources) — what rows look like, what
+  fields are available, and the variable system that markdown and HTML widgets
+  use.
+- [Canvas Expressions](/concepts/expressions) — the canvas-side reference for
+  comparison.

--- a/src/content/docs/concepts/console/widgets.mdx
+++ b/src/content/docs/concepts/console/widgets.mdx
@@ -1,0 +1,660 @@
+---
+title: Widgets
+description: The seven console widget types — what they're for, how to configure them, and a YAML example for each.
+---
+
+The [console](/concepts/console) is a grid of **widgets** (also called panels). This
+page covers each widget type: when to use it, the fields it accepts, and a worked
+YAML example.
+
+Tables, charts, numbers, and the markdown/HTML variable system all read from the
+same [data sources](/concepts/console/data-sources). Templates and conditional
+expressions follow the rules in [Expressions &
+CEL](/concepts/console/expressions).
+
+## Widgets at a glance
+
+| Type | When to use it |
+| --- | --- |
+| [Markdown](#markdown) | Runbooks, notes, status copy, links. Supports live variables. |
+| [HTML](#html) | Custom layout with scoped CSS and Tailwind utilities, with the same variables. |
+| [Node](#node) | Pin one canvas node — status + optional Run button. |
+| [Key Nodes](#key-nodes) | Pin several nodes with a short purpose line for each. |
+| [Table](#table) | Rows from memory, executions, or runs — with filters, formatting, and row actions. |
+| [Chart](#chart) | Bar, stacked-bar, line, area, or donut chart over the same data. |
+| [Number](#number) | One KPI, multiple side-by-side KPIs, or a combined aggregate. |
+
+## Markdown
+
+Use the **Markdown** widget for the prose parts of a console: runbooks,
+playbook links, status explanations, deployment notes.
+
+{/* TODO(image): screenshot of a markdown widget rendering a runbook with a status badge */}
+
+**Authoring features:**
+
+- GitHub-flavored markdown (tables, task lists, strikethrough, autolinks).
+- Soft line breaks (one Enter is a `<br>`, not two paragraphs).
+- Collapsible sections via raw `<details>` / `<summary>`:
+
+  ```markdown
+  <details open>
+  <summary>Troubleshooting</summary>
+
+  - Flush the cache.
+  - Roll back via the **Rollback** node panel.
+
+  </details>
+  ```
+
+  Use `<details open>` to pre-expand a section. The body is still parsed as
+  markdown, so links, lists, and inline formatting keep working inside.
+
+- **Safe-by-default raw HTML.** Inline `<script>`, event handlers (`onclick`,
+  `onerror`, …), and any tag outside the allowlist are stripped at render time. The
+  only raw tags added on top of the default allowlist are `<details>` and
+  `<summary>` (plus the `open` attribute).
+
+### Variables
+
+Markdown widgets can pull live values from canvas memory or recent runs through
+**variables**, then reference them in the title or body with `{{ }}` templates:
+
+```yaml
+- id: deploy-summary
+  type: markdown
+  content:
+    title: "Latest deploy of {{ release.service }}"
+    body: |
+      ## {{ release.service }}
+
+      - Status: **{{ lastRun.status }}**
+      - Triggered by: {{ lastRun.nodeName }}
+      - Output URL: {{ lastRun.$["Deploy"].data.url }}
+    variables:
+      - name: release
+        source:
+          kind: memory
+          namespace: releases
+          orderBy: createdAt
+          direction: desc
+          matches:
+            - field: env
+              value: production
+      - name: lastRun
+        source:
+          kind: run
+          select: latest_passed
+```
+
+See [Variables](/concepts/console/data-sources#variables) for the full source
+options, list mode, and null-safety rules.
+
+### Content fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `title` | no | Card header. Supports `{{ }}` templates. |
+| `body` | no | Markdown body. Supports `{{ }}` templates. |
+| `variables` | no | Named variables resolved from memory or runs. |
+
+## HTML
+
+Use the **HTML** widget when markdown isn't expressive enough — custom badges,
+multi-column layouts, status callouts that need precise styling. HTML widgets share
+the markdown variable system, so anything you can do with `{{ }}` in markdown works
+here too.
+
+{/* TODO(image): screenshot of an HTML widget rendering a styled release card */}
+
+The editor is split into a code pane (monospace textarea for the HTML), a live
+preview, and the variables manager on the right. **Cmd/Ctrl + Enter** saves;
+**Escape** cancels.
+
+### Safety policy
+
+The body is sanitized at render time, after variables are interpolated and before
+the result is inserted into the DOM. The pipeline is:
+
+```text
+interpolate variables -> sanitize allow-list -> scope <style> blocks -> render
+```
+
+In practice:
+
+- **Allowed tags** — structural (`div`, `section`, `article`, `header`, `footer`,
+  `main`, `aside`, `nav`, `p`, `h1`–`h6`, `blockquote`, `pre`, `hr`, `br`), inline
+  text (`span`, `strong`, `em`, `code`, `kbd`, `samp`, `var`, `abbr`, `cite`,
+  `dfn`, `q`, `time`, `data`, and similar), lists (`ul`, `ol`, `li`, `dl`, `dt`,
+  `dd`), tables, links and images (`a`, `img`, `figure`, `figcaption`),
+  interactive (`details`, `summary`), and `<style>` (scoped — see below).
+- **Allowed attributes** — `class`, `style`, `id`, `href`, `src`, `srcset`,
+  `title`, `alt`, `width`, `height`, `colspan`, `rowspan`, `open`, `lang`, `dir`,
+  `role`, `tabindex`, `name`, plus ARIA. Every `on*` event handler is stripped.
+- **Forbidden tags** — `script`, `iframe`, `object`, `embed`, `link`, `meta`,
+  `form` and all form controls, `audio`, `video`, `canvas`, `math`, `svg`. These
+  are removed even if the allow-list says otherwise.
+- **URL allow-list** — `href`, `src`, and `srcset` accept `http(s)`, `mailto:`,
+  `tel:`, fragments (`#…`), and relative paths. `javascript:` and `data:` URLs
+  never survive.
+- **External images load.** `<img src="...">` works for `http(s)` URLs. Cross-origin
+  fetches leak the canvas URL via the `Referer` header and can act as tracking
+  pixels — embed images only from sources you trust.
+
+### Scoped `<style>` blocks
+
+`<style>` blocks are preserved, but every selector is rewritten with a
+panel-specific attribute prefix so styles cannot leak out of the widget. Rules
+referencing `url(...)`, `@import`, and unknown at-rules (`@keyframes`,
+`@font-face`, …) are dropped. `@media` and `@supports` are recursed into so
+scoping still applies.
+
+### Tailwind utilities
+
+A curated Tailwind safelist is bundled into the docs site and made available to
+HTML widgets: layout (display, flex, grid), spacing, sizing, typography, the full
+color palette (`text-*`, `bg-*`, `border-*` for every default shade), borders,
+rounding, shadow, opacity, overflow, positioning, z-index, cursor, and
+transitions.
+
+Interactive variants are safelisted where they matter most:
+
+- `hover:` and `focus:` for color (`text-*`, `bg-*`, `border-*`), display, text
+  decoration (`underline`, `line-through`, `no-underline`), `shadow*`, and
+  `opacity-*`.
+- Hover/focus on sizing, spacing, and typography size families is not safelisted.
+
+The `dark:` variant is not safelisted — pick colors that work in both light and
+dark themes rather than relying on the variant.
+
+### Authoring example
+
+```yaml
+- id: release-card
+  type: html
+  content:
+    title: "{{ release.service }}"
+    body: |
+      <style>
+        .badge {
+          display: inline-block;
+          padding: 2px 6px;
+          border-radius: 4px;
+          font-size: 11px;
+          font-weight: 600;
+        }
+        .badge-passed { background: #dcfce7; color: #166534; }
+        .badge-failed { background: #fee2e2; color: #991b1b; }
+      </style>
+      <div class="flex flex-col gap-2 text-sm">
+        <div class="flex items-center gap-2">
+          <strong>{{ release.service }}</strong>
+          <span class="badge badge-{{ lastRun.status }}">{{ lastRun.status }}</span>
+        </div>
+        <p class="text-slate-600">Triggered by {{ lastRun.nodeName }}.</p>
+      </div>
+    variables:
+      - name: release
+        source:
+          kind: memory
+          namespace: releases
+      - name: lastRun
+        source:
+          kind: run
+          select: latest
+```
+
+### Content fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `title` | no | Card header. Supports `{{ }}` templates. |
+| `body` | no | HTML body. Supports `{{ }}` templates. Sanitized at render time. |
+| `variables` | no | Same shape as markdown variables. |
+
+## Node
+
+Use the **Node** widget to pin one canvas node to the console — current status,
+last run timestamp, and an optional **Run** button to trigger it manually.
+
+{/* TODO(image): screenshot of a Node widget showing status and a Run button */}
+
+Common uses:
+
+- Pin the "Deploy to production" trigger so on-call engineers can promote a
+  release without leaving the console.
+- Pin a "Tear down preview" trigger as a one-click cleanup.
+
+### Content fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `title` | no | Card header. Defaults to the resolved node name. |
+| `node` | yes | Canvas node id or name. |
+| `showRun` | no | When `true`, surface a manual **Run** button. Still requires `canvases:update`. |
+| `triggerName` | no | Start template name when the trigger exposes multiple templates. |
+
+### Example
+
+```yaml
+- id: deploy-prod
+  type: node
+  content:
+    title: Deploy to production
+    node: deploy-production
+    showRun: true
+```
+
+## Key Nodes
+
+The **Key Nodes** widget (panel `type: nodes`) renders several pinned nodes in a
+single card, each with an optional purpose line. Use it for "entry and exit
+points" summaries — the trigger, the deployment, the smoke test, and the cleanup
+— instead of stamping out one Node widget per row.
+
+{/* TODO(image): screenshot of a Key Nodes widget for a preview-environment workflow */}
+
+### Content fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `title` | no | Card header. |
+| `nodes` | yes | Array of pinned nodes. May be empty on a fresh panel; the card shows a "configure me" hint until you add at least one. |
+
+Each entry in `nodes` accepts:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `node` | yes | Canvas node id or name. |
+| `label` | no | Override for the displayed row name. Falls back to the resolved node name. |
+| `description` | no | Short purpose line under the row name. |
+| `showRun` | no | When `true`, surface a manual **Run** button. Still gated by permissions. |
+| `triggerName` | no | Start template name when the trigger exposes multiple templates. |
+
+### Example
+
+```yaml
+- id: pr-workflow
+  type: nodes
+  content:
+    title: Key Nodes
+    nodes:
+      - node: pr-opened
+        description: GitHub PR trigger that boots a new environment.
+      - node: create-droplet
+        description: Provisions the DigitalOcean droplet.
+      - node: health-check
+        description: Confirms the preview is responsive.
+      - node: delete-droplet
+        label: Tear Down
+        description: Releases the droplet when the PR closes.
+        showRun: true
+```
+
+## Table
+
+The **Table** widget is the most configurable widget type. It renders rows from a
+[data source](/concepts/console/data-sources) — memory, executions, or runs —
+with column formatting, structured filters, and optional row actions.
+
+{/* TODO(image): screenshot of a memory-backed Table widget with status badges and a Destroy row action */}
+
+A memory-backed table is the recommended pattern for ephemeral-environment
+consoles (one row per PR, one row per preview, one row per incident).
+
+### Example
+
+```yaml
+type: table
+content:
+  dataSource:
+    kind: memory
+    namespace: environments
+  render:
+    kind: table
+    columns:
+      - field: pr_number
+        label: PR
+      - field: status
+        label: Health
+        format: status
+      - field: created_at
+        label: Uptime
+        format: relative
+    where:
+      - field: status
+        op: neq
+        value: destroyed
+    rowActions:
+      - kind: trigger
+        label: Destroy
+        node: start
+        template: destroy
+        variant: danger
+        confirm: "Destroy PR #{{ pr_number }}?"
+        show: 'status == "running"'
+        payload:
+          issue.number: "{{ pr_number }}"
+```
+
+The editor scans live canvas memory and suggests namespaces and field names. The
+column dropdown, filter inputs, sort field input, and row-action payload chips all
+work off a field catalog derived from the data source — see [Field
+catalogs](/concepts/console/data-sources#field-catalogs).
+
+### Columns
+
+Each column needs a non-empty `field`. The other fields are optional:
+
+| Field | Meaning |
+| --- | --- |
+| `label` | Header text. Falls back to `field`. |
+| `format` | Display format. See the table below. |
+| `show` | Row expression controlling whether the cell is visible. |
+| `href` | Link template for `link`-formatted columns. |
+
+Column `field` accepts a direct dot path (`status`, `payload.user_id`,
+`rootEvent.customName`) or a `{{ CEL }}` template. When the typed value matches a
+known catalog field, the column's `label` and `format` autofill so picking from
+the dropdown stays one click.
+
+**Format values:**
+
+| Format | Renders as |
+| --- | --- |
+| `text` | Plain string (default). |
+| `number` | Locale-aware numeric, with thousands separators. |
+| `percent` | Locale-aware percentage. |
+| `date` | Date only, in the viewer's local timezone. |
+| `datetime` | Date and time, in the viewer's local timezone. |
+| `relative` | "5 minutes ago" / "in 2 days". |
+| `duration` | Human duration. Always interprets input as **milliseconds** — convert from seconds in CEL (`{{ seconds * 1000 }}`) first. |
+| `status` | Colored pill: green for `passed`/`ready`/`active`, red for `failed`, amber for `pending`, sky for `running`. |
+| `badge` | Alias for `status`. |
+| `code` | Monospace text. |
+| `link` | Renders as a hyperlink. Requires `href`. |
+
+### Structured filters
+
+`render.where` is an AND list. Each filter has a `field`, an `op`, and (for most
+operators) a `value`:
+
+| Operator | Meaning |
+| --- | --- |
+| `eq` / `neq` | String equality / inequality. |
+| `contains` / `not_contains` | Substring match. |
+| `gt` / `lt` | Numeric comparison. |
+| `exists` / `not_exists` | Non-empty / empty field. |
+
+Use structured filters when the condition is simple enough to validate. Use
+`{{ CEL }}` in `show` when you need expression power (see
+[Expressions](/concepts/console/expressions)).
+
+### Row actions
+
+Row actions add per-row buttons that invoke a **trigger node** on the canvas. They
+don't call HTTP Request nodes directly — they fire the trigger, and downstream
+steps run because of that, the same as any manual run.
+
+| Field | Meaning |
+| --- | --- |
+| `kind` | Must be `trigger`. |
+| `node` | Trigger node id or name. Required. |
+| `hook` | Trigger hook name. Defaults to `run`. |
+| `template` | Start template name when the trigger supports templates. |
+| `label` | Button label. Defaults to `Run`. |
+| `payload` | Map of dot paths to literals or `{{ CEL }}` templates, merged into trigger parameters. |
+| `confirm` | Optional confirmation dialog text. Supports `{{ }}` interpolation. |
+| `show` | Expression controlling per-row visibility. |
+| `variant` | `default`, `primary`, or `danger`. |
+| `icon` | `play`, `stop`, `trash`, `refresh`, or `external-link`. |
+
+When a row action fires, the widget interpolates the `confirm` text, builds the
+trigger parameters from the row data and the action `payload`, then calls the
+trigger hook. Console queries refresh once the call returns.
+
+## Chart
+
+The **Chart** widget renders the same data sources as Table, grouped into chart
+points. Pick a chart type, an `xField` (the bucket key), and one or more series.
+
+{/* TODO(image): screenshot of a stacked-bar chart and a donut chart side by side */}
+
+### Chart types
+
+| `type` | Shape |
+| --- | --- |
+| `bar` | One bar per `xField` bucket, with each series rendered side-by-side. |
+| `stacked-bar` | One bar per bucket, with series stacked on top of each other. With a single series, this is visually identical to `bar`. |
+| `line` | One line per series across `xField`. |
+| `area` | Same as `line` with filled area below. |
+| `donut` | One slice per distinct `xField` value, valued by the first series. |
+
+Rows that share the same resolved `xField` value are merged into a single chart
+point. If a series omits `field`, the chart **counts** rows per bucket. If
+`field` is set, the chart **sums** numeric values from that field across each
+bucket. Non-numeric values are ignored.
+
+### Example
+
+```yaml
+render:
+  kind: chart
+  type: bar
+  xField: service
+  series:
+    - field: cost
+      label: Cost
+      format: number
+      prefix: "$"
+  legend: auto
+```
+
+### Pivoting long-format rows with `seriesField`
+
+When the data source emits one row per `(X, series)` combination — e.g. one row
+per `(date, service)` cost line — set `seriesField` to pivot those rows into one
+series per distinct value:
+
+```yaml
+render:
+  kind: chart
+  type: stacked-bar
+  xField: date
+  seriesField: service
+  series:
+    - field: cost_usd
+      label: Cost
+      prefix: "$"
+```
+
+When `seriesField` is set, the chart sums the numeric `field` of the **first**
+configured series per `(xField, seriesField)` bucket. Additional series entries
+are ignored for shaping — colors and order come from the data.
+
+### Series formatting
+
+Each series accepts optional display fields used by the hover tooltip and donut
+value rows:
+
+- `format` — `text`, `number`, `percent`, or `duration`. Defaults to `number`.
+  `duration` always interprets input as **milliseconds**.
+- `prefix` — literal string rendered before the value (for example `"$"`).
+- `suffix` — literal string rendered after the value (for example `" MWh"`).
+
+Tooltips show the category in the header and one row per series with
+`label — prefix{value}suffix`. Donut tooltips append the slice's share of the
+total (for example `ec2 — $1,200 (52%)`).
+
+### Legend
+
+`render.legend` controls legend visibility:
+
+- `auto` (default) — visible for donut charts or when 2+ series are configured.
+- `show` — always visible (useful for a single-series chart that needs a label).
+- `hide` — never rendered.
+
+### Axis formatting
+
+Cartesian charts (`bar`, `stacked-bar`, `line`, `area`) expose three optional
+axis fields:
+
+- `xFormat` — display format applied to X-axis tick labels **and the hover
+  tooltip header**. Uses the same vocabulary as column `format` (`text`,
+  `number`, `percent`, `date`, `datetime`, `relative`, `duration`). Set
+  `xFormat: date` when `xField` is a raw timestamp, rather than wrapping it in a
+  CEL expression.
+- `yLabel` — Y-axis title (for example `USD`, `Errors / day`).
+- `yFormat` — display format for Y-axis tick labels (`number`, `percent`,
+  `duration`). Falls back to a locale-aware numeric default with thousands
+  separators above 1k. A series `format` only affects tooltip values — configure
+  `yFormat` to match it on the axis itself.
+
+```yaml
+render:
+  kind: chart
+  type: bar
+  xField: createdAt
+  xFormat: date
+  yLabel: USD
+  yFormat: number
+  series:
+    - field: cost
+      label: Cost
+      format: number
+      prefix: "$"
+```
+
+Donut charts ignore `xFormat`, `yLabel`, and `yFormat` — no axes are rendered.
+
+## Number
+
+The **Number** widget aggregates rows into a KPI. It has three modes: a single
+value, multiple values side-by-side, or one value combined across several memory
+namespaces.
+
+{/* TODO(image): screenshot of a Number widget with a single KPI and a multi-number card */}
+
+### Aggregations
+
+| Aggregation | What it returns |
+| --- | --- |
+| `count` | Number of rows. Doesn't need a `field`. |
+| `sum` | Sum of `field` across rows. |
+| `avg` | Mean of `field` across rows. |
+| `min` / `max` | Min / max of `field`. |
+| `first` / `last` | First / last value of `field` in source order. |
+
+All aggregations except `count` require a non-empty `field`.
+
+### Display symbols
+
+`render.prefix` and `render.suffix` wrap the formatted value with a literal
+string. Use them for currency or units — `prefix: "R$"`, `suffix: " MWh"`. They
+apply after `render.format`, so locale-aware formatting (`number`, `percent`,
+`duration`) is preserved. When the aggregate is null/empty, the widget renders an
+em-dash placeholder without the symbols.
+
+```yaml
+render:
+  kind: number
+  aggregation: sum
+  field: cost
+  format: number
+  prefix: "R$"
+```
+
+### Composite memory sources
+
+Use a composite memory source when the contributing namespaces have different
+schemas — for example "sum of cost" in one namespace and "count of tests" in
+another. Each entry aggregates its own namespace; the partials are then merged
+with `combine`.
+
+```yaml
+type: number
+content:
+  dataSource:
+    kind: memory
+    combine: sum
+    sources:
+      - namespace: expenses
+        aggregation: sum
+        field: cost
+      - namespace: tests
+        aggregation: count
+  render:
+    kind: number
+    format: number
+    prefix: "R$"
+```
+
+**Rules:**
+
+- `sources` is a non-empty array. Each entry needs a non-empty `namespace`, an
+  `aggregation`, and a `field` (unless `aggregation` is `count`). An optional
+  `fieldPath` flattens the entry the same way the single-namespace memory source
+  does.
+- `combine` is one of `sum`, `min`, `max`, or `avg`. `sum` is the default.
+- When `sources` is set, `render.aggregation` and `render.field` must be absent —
+  the per-source configuration is the source of truth.
+- Partial values that resolve to `null` are skipped during combine. The panel
+  renders the em-dash placeholder only when every partial is null.
+- `avg` is an unweighted mean of the available partials, not a row-weighted
+  average across namespaces. Use `sum` when row-level math matters.
+- Sparklines are only available in single-source mode.
+
+The Number form exposes a **Single / Multiple memory sources / Multiple numbers**
+toggle that seeds the new mode from whatever is currently configured.
+
+### Multi-number mode
+
+A Number panel can also render **multiple independently-configured KPIs in one
+card**. Each metric has its own data source, aggregation, field, label, format,
+prefix/suffix, and optional sparkline. The metrics lay out in a flex row that
+wraps when the panel is narrow.
+
+```yaml
+type: number
+content:
+  title: Pipeline KPIs
+  metrics:
+    - dataSource:
+        kind: runs
+      render:
+        kind: number
+        aggregation: count
+        label: Total runs
+    - dataSource:
+        kind: memory
+        namespace: costs
+      render:
+        kind: number
+        aggregation: sum
+        field: cost
+        label: Total cost
+        format: number
+        prefix: "R$"
+```
+
+**Rules:**
+
+- `metrics` is a non-empty array. When present, top-level `dataSource` and
+  `render` are not used and are not required.
+- Each metric's `dataSource` must be a single-source `memory` / `executions` /
+  `runs` shape — the composite (`sources` + `combine`) shape is not allowed
+  inside a metric.
+- Each metric's `render.kind` is `number`. `render.aggregation` is required;
+  `render.field` is required for aggregations other than `count`.
+- Use `render.label` as the metric's name (it renders above the value).
+
+The three modes — single value, composite-combined, and multi-number — are
+disjoint. A Number panel is exactly one of them at a time.
+
+## Where to go next
+
+- [Data sources](/concepts/console/data-sources) — what each source returns,
+  field catalogs, and the variable system used by markdown and HTML widgets.
+- [Expressions & CEL](/concepts/console/expressions) — `{{ }}` templates, the
+  builtins catalog, and how console expressions differ from canvas
+  [Expr](/concepts/expressions).


### PR DESCRIPTION
## Summary

Expands the Console documentation from a single 55-line page into a four-page subsection that matches the depth of Canvas, Expressions, and component references. Content is ported from the upstream [`docs/prd/console-and-widgets.md`](https://github.com/superplanehq/superplane/blob/main/docs/prd/console-and-widgets.md) PRD, filtered to user-facing material only.

## Changes

- **`concepts/console.mdx`** — rewritten as a what / why / how overview: when to use a console, the 12-column grid model, edit flow and permissions table, panel-types index, canonical `console.yaml` shape and rules, import/export semantics, and the install-time `console.yaml` bundling story.
- **`concepts/console/widgets.mdx`** (new) — one in-depth section per panel type: Markdown, HTML, Node, Key Nodes, Table, Chart, Number. Each includes a use case, configuration fields, and a YAML example. Adds the previously undocumented **HTML** widget, Number's three modes (single / composite memory / multi-number), Chart's `seriesField` pivoting and axis formatting, and Table's row actions, structured filters, and full `format` vocabulary.
- **`concepts/console/data-sources.mdx`** (new) — deep dive on `memory`, `executions`, and `runs`: row shapes, field catalogs, the `$` per-node outputs map (mirroring canvas `$['Node'].data`), `durationMs` pitfalls, and the markdown/HTML **variable system** (`memory` + `run` sources, `mode: list`).
- **`concepts/console/expressions.mdx`** (new) — console CEL vs canvas Expr: side-by-side comparison table, where each language runs, the full CEL builtins catalog by category, common patterns, a dedicated **Durations** section, and a **Limitations** section (no postfix after function calls, no `??` / `?.`, `$` rewrite).
- **`src/config/sidebar.mjs`** — nests the four pages under a new **Console** group inside **SuperPlane Apps**.

Image placeholders (`{/* TODO(image): ... */}`) mark spots that would benefit from screenshots (console mode header, edit mode with the panel picker, per-widget examples) so the image pass has a clear checklist.

Resolves #138 .
