### PR TITLE
docs: add section on durable execution

### DIFF
--- a/src/content/docs/concepts/canvas.mdx
+++ b/src/content/docs/concepts/canvas.mdx
@@ -89,6 +89,17 @@ In the UI, versioned canvases expose an **Edit** mode and a **Versioning** view:
 
 For CLI commands, see [SuperPlane CLI](/installation/cli).
 
+## Durable Execution
+
+SuperPlane provides **durable execution** for your workflows. This means that if a node crashes, times out, or the system restarts, the workflow state is preserved.
+
+Because every node's payload is saved to the message chain, a workflow can safely pause and resume without losing data. This is especially important for workflows that:
+- Wait for human approval (which could take days).
+- Call flaky external APIs that might need to be retried.
+- Run long-running scripts on remote runners.
+
+You don't need to write custom retry logic or state-saving code; durable execution is built into the canvas.
+
 ## The Canvas Page
 
 ### Nodes and Connections


### PR DESCRIPTION
Adds a new section to the Canvas concepts page explicitly mentioning and explaining "durable execution". It covers how the state is preserved across crashes, timeouts, and long-running tasks like human approvals or remote scripts.

Resolves #136