### PR TITLE
Expand the Apps Overview page

### DIFF
--- a/src/content/docs/concepts/files.mdx
+++ b/src/content/docs/concepts/files.mdx
@@ -1,12 +1,12 @@
 ---
 title: Files
-description: Each app has a git repository with canvas.yaml and console.yaml — edit from the Files tab or the CLI.
+description: Each app has a git repository. It stores canvas.yaml, console.yaml, and any other files your app needs.
 ---
 
 import filesOverview from "../../../assets/files-overview.png";
 import { Image } from "astro:assets";
 
-Every app is backed by a **git repository**. The **Files** tab is where you view and edit the YAML that defines the app.
+Every app is backed by a **git repository**. The **Files** tab is where you view and edit the files that define the app.
 
 <div class="big-image">
   <figure class="sp-canvas-figure">
@@ -19,6 +19,10 @@ Every app is backed by a **git repository**. The **Files** tab is where you view
 
 ## What's in the repository
 
+Because the app is backed by a standard Git repository, you can store any files you need inside it, such as scripts, READMEs, or custom configuration files. 
+
+However, two files have a special meaning to SuperPlane:
+
 | File | Purpose |
 | ---- | ------- |
 | `canvas.yaml` | Workflow graph: nodes, subscriptions, and configuration |
@@ -30,8 +34,8 @@ Changes you make in the UI are reflected in these files. Edits in **Files** foll
 
 Open **Files** from the app header (alongside **Canvas**, **Console**, and **Memory**).
 
-- View and edit `canvas.yaml` and `console.yaml` in the browser
-- Export YAML for review or backup
+- View and edit files in the browser
+- Export files for review or backup
 - Import YAML to replace the graph or console in one update (console import is replace-all)
 
 ## CLI

--- a/src/content/docs/concepts/glossary.md
+++ b/src/content/docs/concepts/glossary.md
@@ -7,7 +7,7 @@ This page defines the core terms used throughout the SuperPlane documentation.
 
 ## SuperPlane Apps
 
-A **SuperPlane app** is a control plane for long-lived, event-driven SDLC workflows across your existing tools. See [Overview](/concepts/superplane-apps).
+A **SuperPlane app** is a control plane for long-lived, event-driven software engineering workflows across your existing tools. See [Overview](/concepts/superplane-apps).
 
 ## Canvas
 

--- a/src/content/docs/concepts/glossary.md
+++ b/src/content/docs/concepts/glossary.md
@@ -7,7 +7,7 @@ This page defines the core terms used throughout the SuperPlane documentation.
 
 ## SuperPlane Apps
 
-A **SuperPlane app** is a control plane for long-lived, event-driven DevOps workflows across your existing tools. See [Overview](/concepts/superplane-apps).
+A **SuperPlane app** is a control plane for long-lived, event-driven SDLC workflows across your existing tools. See [Overview](/concepts/superplane-apps).
 
 ## Canvas
 

--- a/src/content/docs/concepts/superplane-apps.mdx
+++ b/src/content/docs/concepts/superplane-apps.mdx
@@ -1,12 +1,12 @@
 ---
 title: Overview
-description: A SuperPlane app is a control plane for long-lived, event-driven DevOps workflows across your existing tools.
+description: A SuperPlane app is a control plane for long-lived, event-driven SDLC workflows across your existing tools.
 ---
 
 import appOverviewCanvas from "../../../assets/app-overview-canvas.png";
 import { Image } from "astro:assets";
 
-A **SuperPlane app** is a workspace where you design and run long-lived, event-driven DevOps workflows.
+A **SuperPlane app** is a workspace where you design and run long-lived, event-driven SDLC workflows.
 It consists of an execution engine, git repository, management console and memory.
 
 <div class="big-image">
@@ -22,7 +22,7 @@ Each app brings together four core building blocks:
 - **[Memory](/concepts/canvas-memory)** — Persistent, app-scoped storage for JSON data. Workflows can read and write to memory to share state across runs and power console dashboards.
 - **[Files](/concepts/files)** — The git repository backing the app. It stores the `canvas.yaml` and `console.yaml` definitions, along with any other files or scripts your app needs, enabling version control and infrastructure-as-code practices.
 
-These building blocks work together to provide a complete platform for DevOps automation. You design the logic on the Canvas, store state in Memory, manage operations through the Console, and version everything in Files.
+These building blocks work together to provide a complete platform for SDLC (software delivery lifecycle) automation. You design the logic on the Canvas, store state in Memory, manage operations through the Console, and version everything in Files.
 
 ## How building blocks work together
 

--- a/src/content/docs/concepts/superplane-apps.mdx
+++ b/src/content/docs/concepts/superplane-apps.mdx
@@ -17,7 +17,7 @@ It consists of an execution engine, git repository, management console and memor
 
 Each app brings together four core building blocks:
 
-- **[Canvas](/concepts/canvas)** — The workspace where you design and run workflows visually. It is a graph of nodes connected by subscriptions that define how events flow between steps.
+- **[Canvas](/concepts/canvas)** — The workspace where you design and run workflows. It is a graph of nodes connected by subscriptions that define how events flow between steps. Unlike a linear pipeline, a canvas is an infinite space that can hold multiple independent graphs and define multiple workflows, each with their own paths of execution.
 - **[Console](/concepts/console)** — The operational surface for the app. It turns workflow state into an at-a-glance view with notes, runbooks, pinned nodes, tables of live data, and charts.
 - **[Memory](/concepts/canvas-memory)** — Persistent, app-scoped storage for JSON data. Workflows can read and write to memory to share state across runs and power console dashboards.
 - **[Files](/concepts/files)** — The git repository backing the app. It stores the `canvas.yaml` and `console.yaml` definitions, enabling version control and infrastructure-as-code practices.

--- a/src/content/docs/concepts/superplane-apps.mdx
+++ b/src/content/docs/concepts/superplane-apps.mdx
@@ -15,20 +15,27 @@ It consists of an execution engine, git repository, management console and memor
   </figure>
 </div>
 
-Each app brings together:
+Each app brings together four core building blocks:
 
-- **[Canvas](/concepts/canvas)** — The workflow engine of the app
-- **[Console](/concepts/console)** — The operational console for the app
-- **[Memory](/concepts/canvas-memory)** — Persistent storage for the app
-- **[Files](/concepts/files)** — Git repository backing the app
+- **[Canvas](/concepts/canvas)** — The workspace where you design and run workflows visually. It is a graph of nodes connected by subscriptions that define how events flow between steps.
+- **[Console](/concepts/console)** — The operational surface for the app. It turns workflow state into an at-a-glance view with notes, runbooks, pinned nodes, tables of live data, and charts.
+- **[Memory](/concepts/canvas-memory)** — Persistent, app-scoped storage for JSON data. Workflows can read and write to memory to share state across runs and power console dashboards.
+- **[Files](/concepts/files)** — The git repository backing the app. It stores the `canvas.yaml` and `console.yaml` definitions, enabling version control and infrastructure-as-code practices.
+
+These building blocks work together to provide a complete platform for DevOps automation. You design the logic on the Canvas, store state in Memory, manage operations through the Console, and version everything in Files.
+
+## How building blocks work together
+
+When you build a SuperPlane app, the four core components interact to create a complete operational tool:
+
+1. **Events trigger workflows**: An external event (like a GitHub push or a PagerDuty incident) triggers a node on the **Canvas**.
+2. **Workflows process data**: The canvas executes the workflow, transforming data, calling external APIs, or waiting for human input.
+3. **State is saved**: Throughout the workflow, nodes can read and write JSON data to **Memory**, preserving state across runs.
+4. **Operators monitor and act**: The **Console** reads from Memory and live run data to display dashboards, KPIs, and actionable buttons for human operators.
+5. **Everything is versioned**: The entire configuration of the Canvas and Console is saved in the **Files** repository, allowing you to draft, commit, and publish changes safely.
+
+This architecture means you do not just build a script—you build a fully operational application with its own UI, state, and version history.
 
 ## Getting started
 
-To get started, click the **New App** button in the top-right corner of the page:
-
-1. Click the **New App** button in the top-right corner of the page
-1. Select a prebuilt app template or create a blank app
-1. Click the **Create** button
-
-This will create a new app with a blank canvas, console, memory, and git repository.
-You can then start designing your workflows on the canvas, and manage your app in the console.
+To get started with building your first app, see the [Quickstart](/get-started/quickstart) tutorial.

--- a/src/content/docs/concepts/superplane-apps.mdx
+++ b/src/content/docs/concepts/superplane-apps.mdx
@@ -1,12 +1,12 @@
 ---
 title: Overview
-description: A SuperPlane app is a control plane for long-lived, event-driven SDLC workflows across your existing tools.
+description: A SuperPlane app is a control plane for long-lived, event-driven software engineering workflows across your existing tools.
 ---
 
 import appOverviewCanvas from "../../../assets/app-overview-canvas.png";
 import { Image } from "astro:assets";
 
-A **SuperPlane app** is a workspace where you design and run long-lived, event-driven SDLC workflows.
+A **SuperPlane app** is a workspace where you design and run long-lived, event-driven software engineering workflows.
 It consists of an execution engine, git repository, management console and memory.
 
 <div class="big-image">
@@ -22,7 +22,7 @@ Each app brings together four core building blocks:
 - **[Memory](/concepts/canvas-memory)** — Persistent, app-scoped storage for JSON data. Workflows can read and write to memory to share state across runs and power console dashboards.
 - **[Files](/concepts/files)** — The git repository backing the app. It stores the `canvas.yaml` and `console.yaml` definitions, along with any other files or scripts your app needs, enabling version control and infrastructure-as-code practices.
 
-These building blocks work together to provide a complete platform for SDLC (software delivery lifecycle) automation. You design the logic on the Canvas, store state in Memory, manage operations through the Console, and version everything in Files.
+These building blocks work together to provide a complete platform for software engineering automation. You design the logic on the Canvas, store state in Memory, manage operations through the Console, and version everything in Files.
 
 ## How building blocks work together
 

--- a/src/content/docs/concepts/superplane-apps.mdx
+++ b/src/content/docs/concepts/superplane-apps.mdx
@@ -18,9 +18,9 @@ It consists of an execution engine, git repository, management console and memor
 Each app brings together four core building blocks:
 
 - **[Canvas](/concepts/canvas)** — The workspace where you design and run workflows. It is a graph of nodes connected by subscriptions that define how events flow between steps. Unlike a linear pipeline, a canvas is an infinite space that can hold multiple independent graphs and define multiple workflows, each with their own paths of execution.
-- **[Console](/concepts/console)** — The operational surface for the app. It turns workflow state into an at-a-glance view with notes, runbooks, pinned nodes, tables of live data, and charts.
+- **[Console](/concepts/console)** — The operational surface for the app. It turns workflow state into an at-a-glance view with dashboards, runbooks, tables of live data, and charts.
 - **[Memory](/concepts/canvas-memory)** — Persistent, app-scoped storage for JSON data. Workflows can read and write to memory to share state across runs and power console dashboards.
-- **[Files](/concepts/files)** — The git repository backing the app. It stores the `canvas.yaml` and `console.yaml` definitions, enabling version control and infrastructure-as-code practices.
+- **[Files](/concepts/files)** — The git repository backing the app. It stores the `canvas.yaml` and `console.yaml` definitions, along with any other files or scripts your app needs, enabling version control and infrastructure-as-code practices.
 
 These building blocks work together to provide a complete platform for DevOps automation. You design the logic on the Canvas, store state in Memory, manage operations through the Console, and version everything in Files.
 

--- a/src/content/docs/concepts/superplane-apps.mdx
+++ b/src/content/docs/concepts/superplane-apps.mdx
@@ -7,7 +7,6 @@ import appOverviewCanvas from "../../../assets/app-overview-canvas.png";
 import { Image } from "astro:assets";
 
 A **SuperPlane app** is a workspace where you design and run long-lived, event-driven software engineering workflows.
-It consists of an execution engine, git repository, management console and memory.
 
 <div class="big-image">
   <figure class="sp-canvas-figure">
@@ -17,22 +16,22 @@ It consists of an execution engine, git repository, management console and memor
 
 Each app brings together four core building blocks:
 
-- **[Canvas](/concepts/canvas)** — The workspace where you design and run workflows. It is a graph of nodes connected by subscriptions that define how events flow between steps. Unlike a linear pipeline, a canvas is an infinite space that can hold multiple independent graphs and define multiple workflows, each with their own paths of execution.
+- **[Canvas](/concepts/canvas)** — The workspace where you design and run workflows. It is a graph of nodes connected by subscriptions that define how events flow between steps. Unlike a linear pipeline, a Canvas is an infinite space that can hold multiple independent graphs and define multiple workflows, each with their own paths of execution.
 - **[Console](/concepts/console)** — The operational surface for the app. It turns workflow state into an at-a-glance view with dashboards, runbooks, tables of live data, and charts.
-- **[Memory](/concepts/canvas-memory)** — Persistent, app-scoped storage for JSON data. Workflows can read and write to memory to share state across runs and power console dashboards.
+- **[Memory](/concepts/canvas-memory)** — Persistent, app-scoped storage for JSON data. Workflows can read and write to Memory to share state across runs and power Console dashboards.
 - **[Files](/concepts/files)** — The git repository backing the app. It stores the `canvas.yaml` and `console.yaml` definitions, along with any other files or scripts your app needs, enabling version control and infrastructure-as-code practices.
 
-These building blocks work together to provide a complete platform for software engineering automation. You design the logic on the Canvas, store state in Memory, manage operations through the Console, and version everything in Files.
+These building blocks work together to provide a complete platform for software engineering automation.
 
 ## How building blocks work together
 
 When you build a SuperPlane app, the four core components interact to create a complete operational tool:
 
 1. **Events trigger workflows**: An external event (like a GitHub push or a PagerDuty incident) triggers a node on the **Canvas**.
-2. **Workflows process data**: The canvas executes the workflow, transforming data, calling external APIs, or waiting for human input.
+2. **Workflows process data**: The **Canvas** executes the workflow, transforming data, calling external APIs, or waiting for human input.
 3. **State is saved**: Throughout the workflow, nodes can read and write JSON data to **Memory**, preserving state across runs.
-4. **Operators monitor and act**: The **Console** reads from Memory and live run data to display dashboards, KPIs, and actionable buttons for human operators.
-5. **Everything is versioned**: The entire configuration of the Canvas and Console is saved in the **Files** repository, allowing you to draft, commit, and publish changes safely.
+4. **Operators monitor and act**: The **Console** reads from **Memory** and live run data to display dashboards, KPIs, and actionable buttons for human operators.
+5. **Everything is versioned**: The entire configuration of the **Canvas** and **Console** is saved in the **Files** repository, allowing you to draft, commit, and publish changes safely.
 
 This architecture means you do not just build a script—you build a fully operational application with its own UI, state, and version history.
 


### PR DESCRIPTION
Expands the SuperPlane Apps overview page to better explain our vision for the core building blocks and how they work together to form a complete operational tool. 

It addresses the feedback in #135 by expanding the stub, removing the overlap with the Quickstart guide, and correcting the description of the Canvas.

Resolves #135