### PR TITLE
docs: add Cloud beta page

### DIFF
--- a/src/config/sidebar.mjs
+++ b/src/config/sidebar.mjs
@@ -6,6 +6,7 @@ export const sidebar = [
       { label: "Welcome", slug: "" },
       { label: "Quickstart", slug: "get-started/quickstart" },
       { label: "Example use cases", slug: "get-started/example-use-cases" },
+      { label: "Cloud beta", slug: "concepts/cloud" },
     ],
   },
   {

--- a/src/content/docs/concepts/cloud.md
+++ b/src/content/docs/concepts/cloud.md
@@ -3,7 +3,7 @@ title: Cloud beta
 description: SuperPlane Cloud is a hosted version of SuperPlane, currently in public beta.
 ---
 
-SuperPlane is available as a **hosted cloud service** and as a **self-hosted** open source deployment. The cloud version is currently in public beta — free to use with usage limits that apply during beta.
+SuperPlane is available as a [hosted cloud service](https://app.superplane.com) (currently in public beta) and as a [self-hosted](/installation/overview) open source deployment. The cloud version is free during beta with usage limits.
 
 ## Feature comparison
 

--- a/src/content/docs/concepts/cloud.md
+++ b/src/content/docs/concepts/cloud.md
@@ -1,0 +1,54 @@
+---
+title: Cloud beta
+description: SuperPlane Cloud is a hosted version of SuperPlane, currently in public beta.
+---
+
+SuperPlane is available as a **hosted cloud service** and as a **self-hosted** open source deployment. The cloud version is currently in public beta — free to use with usage limits that apply during beta.
+
+## Feature comparison
+
+Both cloud and self-hosted share the same core platform. A few features differ:
+
+| Feature | Cloud beta | Self-hosted |
+| ------- | ---------- | ----------- |
+| Canvas, Console, Memory, Files | ✅ | ✅ |
+| Integrations (40+) | ✅ | ✅ |
+| CLI | ✅ | ✅ |
+| Built-in agent | ✅ Included | Requires Anthropic API key and managed agent setup |
+| Managed runners | ✅ Included | Coming soon |
+
+### Built-in agent
+
+On cloud, the [built-in agent](/concepts/agent) works out of the box. On self-hosted, you need to configure your own Anthropic API key, agent ID, and environment ID. See the [agent documentation](/concepts/agent#provider-setup) for setup details.
+
+### Managed runners
+
+[Runners](/concepts/runners) execute shell commands, scripts, and Docker jobs on managed machines. On cloud, you select a machine type and SuperPlane handles provisioning. Managed runners are coming to self-hosted in a future release.
+
+## Usage limits
+
+During the beta, all accounts are free. The following limits apply:
+
+### Retention window
+
+Run history, event payloads, and execution data are retained for **14 days**. After 14 days, this data is automatically cleaned up. This includes:
+
+- Events on trigger and action nodes
+- Run chains and run item details
+- Execution payloads and configuration snapshots
+
+Canvas definitions, console layouts, memory, and files are not affected by the retention window.
+
+### Event budget
+
+Each organization has a budget of **50,000 events per month**. An event is created each time a node executes — whether it is a trigger firing, an action running, or a component emitting a payload.
+
+### Increased limits
+
+Increased usage limits will be available on paid accounts after general availability. If you need higher limits during the beta, contact [support@superplane.com](mailto:support@superplane.com).
+
+## Getting started
+
+Sign up at [app.superplane.com](https://app.superplane.com) to start using SuperPlane Cloud. No credit card required during the beta.
+
+For self-hosted deployments, see the [installation guide](/installation/overview).

--- a/src/content/docs/concepts/cloud.md
+++ b/src/content/docs/concepts/cloud.md
@@ -41,7 +41,7 @@ Canvas definitions, console layouts, memory, and files are not affected by the r
 
 ### Event budget
 
-Each organization has a budget of **50,000 events per month**. An event is created each time a node executes — whether it is a trigger firing, an action running, or a component emitting a payload.
+Each organization has a budget of **500,000 events per month**. An event is created each time a node executes — whether it is a trigger firing, an action running, or a component emitting a payload.
 
 ### Increased limits
 


### PR DESCRIPTION
Adds a Cloud beta page covering:

- **Feature comparison** — cloud vs self-hosted (agent, managed runners)
- **Usage limits** — 14-day retention window, 50k events/month
- **Retention window** explained — what data is affected, what isn't
- **Increased limits** — paid accounts after GA, or contact support now

Sidebar: placed under Get Started after Example use cases.

Closes #153