### PR TITLE
docs: document markdown alerts, sections, Mermaid, and chips

### DIFF
--- a/src/content/docs/concepts/console.mdx
+++ b/src/content/docs/concepts/console.mdx
@@ -88,7 +88,7 @@ for the full reference.
 
 | Panel | Purpose |
 | --- | --- |
-| **Markdown** | Notes, runbooks, and status copy with GitHub-flavored markdown and live variables. |
+| **Markdown** | Notes, runbooks, and status copy with GitHub-flavored markdown, alerts, sections, Mermaid, canvas chips, and live variables. |
 | **HTML** | Custom HTML with scoped `<style>` blocks and a Tailwind utility safelist. |
 | **Node** | Pin one canvas node with live status and an optional Run button. |
 | **Key Nodes** | Pin several nodes in one card with short purpose lines. |

--- a/src/content/docs/concepts/console/widgets.mdx
+++ b/src/content/docs/concepts/console/widgets.mdx
@@ -95,36 +95,38 @@ free-form color value. Syntax: `[!SECTION:preset] Title`.
 
 | Preset | Accent | Typical use |
 | --- | --- | --- |
-| `tools` | Violet | Tooling, CLIs, helper nodes |
-| `rules` | Emerald | Standing rules, policy, guardrails |
-| `skills` | Cyan | Playbooks, how-tos, agent skills |
-| `integrations` | Sky | Connected integrations and wiring |
-| `folder` | Slate | Nested groups, folders, catch-alls |
+| `overview` | Slate | What this app/workflow is for |
+| `setup` | Sky | Prerequisites, secrets, first-time config |
+| `runbook` | Emerald | Step-by-step operating procedure |
+| `run` | Blue | Promote / release / go-live steps |
+| `troubleshoot` | Amber | Failures, checks, how to unblock |
+| `agent` | Violet | Notes and standing instructions for agents |
+| `integrations` | Cyan | Connected integrations and wiring |
+| `group` | Slate (muted) | Nested grouping when no stronger preset fits |
 
 ```markdown
-> [!SECTION:rules] Production guardrails
-> Require two approvals before promoting to prod.
+> [!SECTION:runbook] Production promote
+> Require two approvals, then run the canary.
 
-> [!SECTION:tools] Rollback tools
-> Use `[Rollback](node:rollback-production)` when the canary fails.
+> [!SECTION:agent] Agent notes
+> Prefer `node:` chips when linking canvas steps.
 ```
 
-Root sections without a preset use `rules`. Nested sections without a preset
-use `folder`.
+Root sections without a preset use `runbook`. Nested sections without a preset
+use `group`.
 
 #### Trailing meta
 
 Optional text after a middle dot (` · `) in the title appears on the right of
 the header. Use it for SuperPlane context such as environment, owner, or step
-count — not for unrelated metrics.
+count.
 
 ```markdown
-> [!SECTION:skills] Deploy checklist · prod
-> 1. Run canary.
-> 2. Wait for health check.
-> 3. Promote with `[Deploy](node:http-request-deploy-a1b2c3)`.
+> [!SECTION:run] Promote after green canary · prod
+> 1. Confirm health checks passed.
+> 2. Promote with `[Deploy](node:http-request-deploy-a1b2c3)`.
 
-> [!SECTION:folder] Preview cleanup · on-call
+> [!SECTION:group] Preview cleanup · on-call
 > Tear down with `[Delete preview](node:digitalocean-delete-droplet-f9e8d7)`.
 ```
 

--- a/src/content/docs/concepts/console/widgets.mdx
+++ b/src/content/docs/concepts/console/widgets.mdx
@@ -88,22 +88,48 @@ a count of its **direct** nested sections next to the title.
 > > Prefer the **Flush cache** node over manual Redis commands.
 ```
 
-Optional pieces:
+#### Presets and colors
 
-- **Preset** for icon and header tint: `tools`, `rules`, `skills`, `mcp`, or
-  `folder`.
+You pick color (and icon) with a **named preset** in the marker — there is no
+free-form color value. Syntax: `[!SECTION:preset] Title`.
 
-  ```markdown
-  > [!SECTION:rules] Standing rules · ~5,366
-  > Keep instructions short and actionable.
-  ```
+| Preset | Accent | Typical use |
+| --- | --- | --- |
+| `tools` | Violet | Tooling, CLIs, helper nodes |
+| `rules` | Emerald | Standing rules, policy, guardrails |
+| `skills` | Cyan | Playbooks, how-tos, agent skills |
+| `mcp` | Sky | MCP / integration wiring |
+| `folder` | Slate | Nested groups, folders, catch-alls |
 
-- **Trailing meta** after a middle dot (` · `) in the title — useful for token
-  counts or similar labels. The title is the text before the separator; the
-  trailing text appears on the right of the header.
+```markdown
+> [!SECTION:rules] Production guardrails
+> Require two approvals before promoting to prod.
 
-Root sections without a preset use the `rules` look; nested sections default
-to `folder`.
+> [!SECTION:tools] Rollback tools
+> Use `[Rollback](node:rollback-production)` when the canary fails.
+```
+
+Root sections without a preset use `rules`. Nested sections without a preset
+use `folder`.
+
+#### Trailing meta
+
+Optional text after a middle dot (` · `) in the title appears on the right of
+the header. Use it for SuperPlane context such as environment, owner, or step
+count — not for unrelated metrics.
+
+```markdown
+> [!SECTION:skills] Deploy checklist · prod
+> 1. Run canary.
+> 2. Wait for health check.
+> 3. Promote with `[Deploy](node:deploy-production)`.
+
+> [!SECTION:folder] Preview cleanup · on-call
+> Tear down with `[Delete preview](node:delete-preview)`.
+```
+
+The title is the text before the separator; the trailing text is everything
+after it.
 
 Raw HTML `<details>` / `<summary>` still works when you need a pre-expanded
 block (`<details open>`) or markup that is not a blockquote:

--- a/src/content/docs/concepts/console/widgets.mdx
+++ b/src/content/docs/concepts/console/widgets.mdx
@@ -16,7 +16,7 @@ CEL](/concepts/console/expressions).
 
 | Type | When to use it |
 | --- | --- |
-| [Markdown](#markdown) | Runbooks, notes, status copy, links. Supports live variables. |
+| [Markdown](#markdown) | Runbooks, notes, status copy, links. Alerts, sections, Mermaid, chips, and live variables. |
 | [HTML](#html) | Custom layout with scoped CSS and Tailwind utilities, with the same variables. |
 | [Node](#node) | Pin one canvas node — status + optional Run button. |
 | [Key Nodes](#key-nodes) | Pin several nodes with a short purpose line for each. |
@@ -27,7 +27,9 @@ CEL](/concepts/console/expressions).
 ## Markdown
 
 Use the **Markdown** widget for the prose parts of a console: runbooks,
-playbook links, status explanations, deployment notes.
+playbook links, status explanations, deployment notes. The same markdown
+renderer powers **Files** `.md` previews, so authoring features below work in
+both places.
 
 {/* TODO(image): screenshot of a markdown widget rendering a runbook with a status badge */}
 
@@ -35,68 +37,118 @@ playbook links, status explanations, deployment notes.
 
 - GitHub-flavored markdown (tables, task lists, strikethrough, autolinks).
 - Soft line breaks (one Enter is a `<br>`, not two paragraphs).
-- Collapsible sections via raw `<details>` / `<summary>`:
-
-  ```markdown
-  <details open>
-  <summary>Troubleshooting</summary>
-
-  - Flush the cache.
-  - Roll back via the **Rollback** node panel.
-
-  </details>
-  ```
-
-  Use `<details open>` to pre-expand a section. The body is still parsed as
-  markdown, so links, lists, and inline formatting keep working inside.
-
+- [GitHub-style alerts](#alerts) for callouts (`NOTE`, `TIP`, `IMPORTANT`,
+  `WARNING`, `CAUTION`).
+- [Collapsible sections](#sections) with `[!SECTION]` (preferred) or raw
+  `<details>` / `<summary>`.
+- [Mermaid diagrams](#mermaid-diagrams) from fenced `mermaid` code blocks, with
+  expand and pan/zoom in the fullscreen view.
+- [Canvas chips](#canvas-chips) via `node:` and `integration:` links.
 - **Safe-by-default raw HTML.** Inline `<script>`, event handlers (`onclick`,
   `onerror`, …), and any tag outside the allowlist are stripped at render time. The
   only raw tags added on top of the default allowlist are `<details>` and
   `<summary>` (plus the `open` attribute).
 
-### Variables
+### Alerts
 
-Markdown widgets can pull live values from canvas memory or recent runs through
-**variables**, then reference them in the title or body with `{{ }}` templates:
+GitHub alert blockquotes render with SuperPlane chrome (accent bar + label).
+Put the marker on its own line inside the quote:
 
-```yaml
-- id: deploy-summary
-  type: markdown
-  content:
-    title: "Latest deploy of {{ release.service }}"
-    body: |
-      ## {{ release.service }}
+```markdown
+> [!NOTE]
+> Rollouts pause when the canary error rate exceeds 2%.
 
-      - Status: **{{ lastRun.status }}**
-      - Triggered by: {{ lastRun.nodeName }}
-      - Output URL: {{ lastRun.$["Deploy"].data.url }}
-    variables:
-      - name: release
-        source:
-          kind: memory
-          namespace: releases
-          orderBy: createdAt
-          direction: desc
-          matches:
-            - field: env
-              value: production
-      - name: lastRun
-        source:
-          kind: run
-          select: latest_passed
+> [!TIP]
+> Prefer linking the **Deploy** node with `[Deploy](node:deploy-production)`.
+
+> [!IMPORTANT]
+> Production deploys require two approvals.
+
+> [!WARNING]
+> Do not re-run failed migrations without checking the run payload.
+
+> [!CAUTION]
+> This action deletes the preview environment.
 ```
 
-See [Variables](/concepts/console/data-sources#variables) for the full source
-options, list mode, and null-safety rules.
+Supported markers: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`. Unknown
+markers (for example `[!TODO]`) stay as plain blockquotes.
 
-### Content fields
+### Sections
 
-| Field | Required | Meaning |
-| --- | --- | --- |
-| `title` | no | Card header. Supports `{{ }}` templates. |
-| `body` | no | Markdown body. Supports `{{ }}` templates. |
-| `variables` | no | Named variables resolved from memory or runs. |
+Use `[!SECTION]` for collapsible runbook sections. Sections start collapsed;
+click the header to expand. Nested sections are supported, and a parent shows
+a count of its **direct** nested sections next to the title.
+
+```markdown
+> [!SECTION] Troubleshooting
+> Flush the cache, then re-run the health check.
+>
+> > [!SECTION] Cache
+> > Prefer the **Flush cache** node over manual Redis commands.
+```
+
+Optional pieces:
+
+- **Preset** for icon and header tint: `tools`, `rules`, `skills`, `mcp`, or
+  `folder`.
+
+  ```markdown
+  > [!SECTION:rules] Standing rules · ~5,366
+  > Keep instructions short and actionable.
+  ```
+
+- **Trailing meta** after a middle dot (` · `) in the title — useful for token
+  counts or similar labels. The title is the text before the separator; the
+  trailing text appears on the right of the header.
+
+Root sections without a preset use the `rules` look; nested sections default
+to `folder`.
+
+Raw HTML `<details>` / `<summary>` still works when you need a pre-expanded
+block (`<details open>`) or markup that is not a blockquote:
+
+```markdown
+<details open>
+<summary>Troubleshooting</summary>
+
+- Flush the cache.
+- Roll back via the **Rollback** node panel.
+
+</details>
+```
+
+The body inside `<details>` is still parsed as markdown.
+
+### Mermaid diagrams
+
+Fenced `mermaid` code blocks render as diagrams. Use the expand control to
+open a fullscreen view with fit-to-viewport, zoom, and pan:
+
+````markdown
+```mermaid
+flowchart LR
+  start[Start] --> deploy[Deploy]
+  deploy --> verify[Verify]
+```
+````
+
+Other fenced languages keep the shared code-block chrome (including expand
+where available).
+
+### Canvas chips
+
+Special link schemes become interactive chips when canvas context is available
+(console markdown and Files on a canvas):
+
+| Link | Renders as |
+| --- | --- |
+| `[Deploy](node:deploy-production)` | Node chip — hover for details; click focuses the node on the live canvas (or the run canvas while inspecting a run). |
+| `[GitHub](integration:github)` | Integration chip for that integration ref. |
+
+Regular `http(s)`, relative, `mailto:`, and fragment links stay normal anchors.
+
+### Variables
 
 ## HTML
 

--- a/src/content/docs/concepts/console/widgets.mdx
+++ b/src/content/docs/concepts/console/widgets.mdx
@@ -98,7 +98,7 @@ free-form color value. Syntax: `[!SECTION:preset] Title`.
 | `tools` | Violet | Tooling, CLIs, helper nodes |
 | `rules` | Emerald | Standing rules, policy, guardrails |
 | `skills` | Cyan | Playbooks, how-tos, agent skills |
-| `mcp` | Sky | MCP / integration wiring |
+| `integrations` | Sky | Connected integrations and wiring |
 | `folder` | Slate | Nested groups, folders, catch-alls |
 
 ```markdown

--- a/src/content/docs/concepts/console/widgets.mdx
+++ b/src/content/docs/concepts/console/widgets.mdx
@@ -59,7 +59,7 @@ Put the marker on its own line inside the quote:
 > Rollouts pause when the canary error rate exceeds 2%.
 
 > [!TIP]
-> Prefer linking the **Deploy** node with `[Deploy](node:deploy-production)`.
+> Prefer linking the deploy node with `[Deploy](node:http-request-deploy-a1b2c3)`.
 
 > [!IMPORTANT]
 > Production deploys require two approvals.
@@ -122,10 +122,10 @@ count — not for unrelated metrics.
 > [!SECTION:skills] Deploy checklist · prod
 > 1. Run canary.
 > 2. Wait for health check.
-> 3. Promote with `[Deploy](node:deploy-production)`.
+> 3. Promote with `[Deploy](node:http-request-deploy-a1b2c3)`.
 
 > [!SECTION:folder] Preview cleanup · on-call
-> Tear down with `[Delete preview](node:delete-preview)`.
+> Tear down with `[Delete preview](node:digitalocean-delete-droplet-f9e8d7)`.
 ```
 
 The title is the text before the separator; the trailing text is everything
@@ -165,12 +165,37 @@ where available).
 ### Canvas chips
 
 Special link schemes become interactive chips when canvas context is available
-(console markdown and Files on a canvas):
+(console markdown and Files on a canvas).
 
-| Link | Renders as |
+#### Node chips
+
+Use `node:<node-id>` — the value after `node:` is the canvas **node id**, not
+the display name. The markdown link text is the label shown on the chip.
+
+```markdown
+[Deploy](node:http-request-deploy-a1b2c3)
+```
+
+Node ids look like `{component}-{name}-{6-char}` (for example
+`http-request-deploy-a1b2c3`). Find one by selecting the node on the canvas —
+the id appears in the node panel and in the URL as `?node=<id>`.
+
+Hover a chip for node details; click it to select and fit that node on the live
+canvas (or on the run canvas while inspecting a run).
+
+#### Integration chips
+
+Use `integration:<ref>`:
+
+| Ref | Meaning |
 | --- | --- |
-| `[Deploy](node:deploy-production)` | Node chip — hover for details; click focuses the node on the live canvas (or the run canvas while inspecting a run). |
-| `[GitHub](integration:github)` | Integration chip for that integration ref. |
+| Integration name (for example `github`) | Chip for that integration type — connect/create when none is linked yet. |
+| Connected instance UUID | Chip for a specific connected integration instance. |
+
+```markdown
+[GitHub](integration:github)
+[Prod Slack](integration:791ee6d1-4c2a-4f0b-9c1d-0a1b2c3d4e5f)
+```
 
 Regular `http(s)`, relative, `mailto:`, and fragment links stay normal anchors.
 


### PR DESCRIPTION
## Summary
- Document GitHub-style alerts, `[!SECTION]` collapsibles, Mermaid expand, and canvas chips
- Document SuperPlane section presets: `overview`, `setup`, `runbook`, `run`, `troubleshoot`, `agent`, `integrations`, `group`
- Clarify that `node:` links use canvas node ids

Updates [Widgets → Markdown](https://docs.superplane.com/concepts/console/widgets/#markdown).

## Test plan
- [x] `npm run build` succeeds
- [ ] Spot-check Markdown section anchors on a preview deploy